### PR TITLE
Api

### DIFF
--- a/OSIR/bin/orc_outcome.py
+++ b/OSIR/bin/orc_outcome.py
@@ -1,0 +1,1457 @@
+import argparse
+import json
+import logging
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def setup_logger(verbose: bool = False) -> logging.Logger:
+    logger = logging.getLogger("orc_outcome")
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+    if logger.handlers:
+        return logger
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+    formatter = logging.Formatter(
+        "[%(levelname)s] %(asctime)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+def parse_iso(value: str | None):
+    if not value:
+        return None
+
+    value = value.strip()
+
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+    ):
+        try:
+            return datetime.strptime(value, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+
+    raise ValueError(f"Unsupported ISO datetime format: {value}")
+
+
+def duration_seconds(start: str | None, end: str | None):
+    s = parse_iso(start)
+    e = parse_iso(end)
+    if not s or not e:
+        return None
+    return int((e - s).total_seconds())
+
+
+def load_json(path: Path, logger: logging.Logger) -> dict:
+    logger.debug(f"Loading JSON: {path}")
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_outline(data: dict) -> dict:
+    return data.get("dfir-orc", {}).get("outline", {})
+
+
+def get_outcome(data: dict) -> dict:
+    return data.get("dfir-orc", {}).get("outcome", {})
+
+
+def status_code(status: str) -> int:
+    return {"ok": 0, "warning": 1, "error": 2}.get(status, 2)
+
+
+def normalize_filename(name: str, computer_name: str) -> str:
+    if not name:
+        return ""
+    return (
+        name.replace("{FullComputerName}", computer_name)
+        .replace("{ComputerName}", computer_name)
+        .lower()
+    )
+
+
+def strip_p7b(name: str) -> str:
+    return re.sub(r"\.p7b$", "", name or "", flags=re.IGNORECASE)
+
+
+def parse_size_to_bytes(value):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+
+    text = str(value).strip()
+    if not text or text.upper() == "N/A":
+        return None
+
+    m = re.match(r"^\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGTP]?B)?\s*$", text, flags=re.IGNORECASE)
+    if not m:
+        return None
+
+    number = float(m.group(1))
+    unit = (m.group(2) or "B").upper()
+
+    multipliers = {
+        "B": 1,
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+        "TB": 1024**4,
+        "PB": 1024**5,
+    }
+    return int(number * multipliers[unit])
+
+
+def find_single_json(run_dir: Path, kind: str, logger: logging.Logger) -> Path:
+    matches = sorted(run_dir.glob(f"DFIR-ORC-{kind}_*.json"))
+    logger.debug(f"Looking for DFIR-ORC-{kind}_*.json in {run_dir}: found {len(matches)}")
+    if len(matches) != 1:
+        raise FileNotFoundError(
+            f"Expected exactly one DFIR-ORC-{kind}_*.json in {run_dir}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def build_disk_index(run_dir: Path, logger: logging.Logger, skip_json=True) -> dict[str, list[dict]]:
+    logger.info(f"Indexing files under: {run_dir}")
+    index: dict[str, list[dict]] = defaultdict(list)
+    file_count = 0
+
+    for p in run_dir.rglob("*"):
+        if not p.is_file():
+            continue
+
+        if skip_json and p.name.lower().startswith("dfir-orc-") and p.suffix.lower() == ".json":
+            continue
+
+        entry = {
+            "path": str(p),
+            "size": p.stat().st_size,
+            "relpath": str(p.relative_to(run_dir)),
+            "name": p.name,
+            "name_lower": p.name.lower(),
+        }
+        index[p.name.lower()].append(entry)
+        file_count += 1
+
+    logger.info(f"Indexed {file_count} files")
+    return index
+
+
+def build_outcome_inventory(
+    outcome: dict,
+    logger: logging.Logger,
+) -> tuple[dict[str, list[dict]], dict[str, dict], dict[tuple[str, str], dict]]:
+    file_index: dict[str, list[dict]] = defaultdict(list)
+    archive_index: dict[str, dict] = {}
+    command_index: dict[tuple[str, str], dict] = {}
+
+    archive_count = 0
+    command_count = 0
+    file_count = 0
+
+    for cs in outcome.get("command_set", []):
+        archive_keyword = cs.get("name")
+        archive_index[archive_keyword] = cs
+        archive_count += 1
+
+        for f in cs.get("archive", {}).get("files", []):
+            file_index[f.get("name", "").lower()].append(
+                {
+                    "archive_keyword": archive_keyword,
+                    "size": f.get("size"),
+                    "name": f.get("name"),
+                }
+            )
+            file_count += 1
+
+        for cmd in cs.get("commands", []):
+            command_index[(archive_keyword, cmd.get("name"))] = cmd
+            command_count += 1
+
+    logger.info(
+        f"Built outcome inventory: {archive_count} archives, {command_count} commands, {file_count} archived files"
+    )
+    return file_index, archive_index, command_index
+
+
+def emit_base_fields(outline: dict, outcome: dict, module_name: str) -> dict:
+    return {
+        "module": module_name,
+        "orc_id": outcome.get("id") or outline.get("id"),
+        "timestamp": outcome.get("timestamp") or outline.get("timestamp"),
+        "computer_name": outcome.get("computer_name") or outline.get("computer_name"),
+        "system_type": outcome.get("system_type") or outline.get("system_type"),
+    }
+
+
+def build_run_summary(outline: dict, outcome: dict, disk_index: dict[str, list[dict]]) -> dict:
+    process_user = outline.get("process", {}).get("user", {})
+    base = emit_base_fields(outline, outcome, "orc_outcome")
+
+    expected_archive_count = len(outline.get("archives", []))
+    outcome_archive_count = len(outcome.get("command_set", []))
+    disk_file_count = sum(len(v) for v in disk_index.values())
+
+    return {
+        **base,
+        "event_type": "orc_run_summary",
+        "start": outcome.get("start") or outline.get("start"),
+        "end": outcome.get("end"),
+        "duration_seconds": duration_seconds(
+            outcome.get("start") or outline.get("start"), outcome.get("end")
+        ),
+        "orc_version": outcome.get("wolf_launcher", {}).get("version") or outline.get("version"),
+        "mothership_sha1": outcome.get("mothership", {}).get("sha1")
+        or outline.get("mothership", {}).get("sha1"),
+        "wolf_launcher_sha1": outcome.get("wolf_launcher", {}).get("sha1"),
+        "mothership_command_line": outcome.get("mothership", {}).get("command_line")
+        or outline.get("mothership", {}).get("command_line"),
+        "wolf_launcher_command_line": outcome.get("wolf_launcher", {}).get("command_line")
+        or outline.get("process", {}).get("command_line"),
+        "output_path": outline.get("output"),
+        "temp_path": outline.get("temp"),
+        "user_name": process_user.get("username"),
+        "user_sid": process_user.get("SID"),
+        "user_elevated": process_user.get("elevated"),
+        "user_locale": process_user.get("locale"),
+        "user_language": process_user.get("language"),
+        "expected_archive_count": expected_archive_count,
+        "outcome_archive_count": outcome_archive_count,
+        "disk_file_count": disk_file_count,
+        "status": "ok",
+        "status_code": 0,
+    }
+
+
+def validate_archives(
+    outline: dict, outcome: dict, run_dir: Path, logger: logging.Logger
+) -> tuple[list[dict], list[dict]]:
+    base = emit_base_fields(outline, outcome, "orc_outcome")
+    outcome_archives = {cs.get("name"): cs for cs in outcome.get("command_set", [])}
+    events = []
+    issues = []
+
+    logger.info("Validating outer ORC archives")
+
+    for archive in outline.get("archives", []):
+        keyword = archive.get("keyword")
+        expected_archive_name = archive.get("file")
+        actual = outcome_archives.get(keyword)
+
+        physical_path = run_dir / expected_archive_name if expected_archive_name else None
+        physical_exists = physical_path.exists() if physical_path else False
+        physical_size = physical_path.stat().st_size if physical_exists else None
+
+        status = "ok"
+        problem_list = []
+
+        if not actual:
+            status = "error"
+            problem_list.append("missing_archive_group_in_outcome")
+
+        if not physical_exists:
+            status = "error"
+            problem_list.append("missing_outer_archive_on_disk")
+            logger.warning(f"Missing outer archive on disk: {expected_archive_name}")
+
+        actual_archive_name = None
+        actual_archive_size = None
+        actual_archive_sha1 = None
+        expected_command_count = len(archive.get("commands", []))
+        actual_command_count = 0
+
+        if actual:
+            actual_archive_name = actual.get("archive", {}).get("name")
+            actual_archive_size = actual.get("archive", {}).get("size")
+            actual_archive_sha1 = actual.get("archive", {}).get("sha1")
+            actual_command_count = len(actual.get("commands", []))
+
+            if strip_p7b(actual_archive_name).lower() != (expected_archive_name or "").lower():
+                status = "warning" if status == "ok" else status
+                problem_list.append("archive_filename_mismatch")
+                logger.warning(
+                    f"Archive filename mismatch for {keyword}: expected={expected_archive_name}, outcome={actual_archive_name}"
+                )
+
+        events.append(
+            {
+                **base,
+                "event_type": "orc_archive_validation",
+                "archive_keyword": keyword,
+                "expected_archive_name": expected_archive_name,
+                "outcome_archive_name": actual_archive_name,
+                "outcome_archive_size": actual_archive_size,
+                "outcome_archive_sha1": actual_archive_sha1,
+                "physical_archive_path": str(physical_path) if physical_path else None,
+                "physical_archive_exists": physical_exists,
+                "physical_archive_size": physical_size,
+                "expected_command_count": expected_command_count,
+                "actual_command_count": actual_command_count,
+                "status": status,
+                "status_code": status_code(status),
+                "issues": problem_list,
+            }
+        )
+
+        for p in problem_list:
+            issues.append(
+                {
+                    **base,
+                    "event_type": "orc_validation_issue",
+                    "archive_keyword": keyword,
+                    "severity": status,
+                    "issue_code": p,
+                    "status": status,
+                    "status_code": status_code(status),
+                }
+            )
+
+    return events, issues
+
+
+def validate_commands(outline: dict, outcome: dict, logger: logging.Logger) -> tuple[list[dict], list[dict]]:
+    base = emit_base_fields(outline, outcome, "orc_outcome")
+    outcome_cmds = {}
+
+    for cs in outcome.get("command_set", []):
+        for cmd in cs.get("commands", []):
+            outcome_cmds[(cs.get("name"), cmd.get("name"))] = cmd
+
+    events = []
+    issues = []
+
+    logger.info("Validating commands")
+
+    for archive in outline.get("archives", []):
+        keyword = archive.get("keyword")
+
+        for cmd in archive.get("commands", []):
+            name = cmd.get("name")
+            actual = outcome_cmds.get((keyword, name))
+
+            if not actual:
+                logger.warning(f"Missing command in outcome: archive={keyword}, command={name}")
+                status = "error"
+                problems = ["missing_command_in_outcome"]
+                event = {
+                    **base,
+                    "event_type": "orc_command_validation",
+                    "archive_keyword": keyword,
+                    "command_name": name,
+                    "tool": None,
+                    "start": None,
+                    "end": None,
+                    "duration_seconds": None,
+                    "exit_code": None,
+                    "status": status,
+                    "status_code": status_code(status),
+                    "issues": problems,
+                }
+                events.append(event)
+
+                for p in problems:
+                    issues.append(
+                        {
+                            **base,
+                            "event_type": "orc_validation_issue",
+                            "archive_keyword": keyword,
+                            "command_name": name,
+                            "severity": status,
+                            "issue_code": p,
+                            "status": status,
+                            "status_code": status_code(status),
+                        }
+                    )
+                continue
+
+            problems = []
+            status = "ok"
+
+            if actual.get("exit_code") != 0:
+                status = "warning"
+                problems.append("non_zero_exit_code")
+                logger.warning(
+                    f"Non-zero exit code for archive={keyword}, command={name}: {actual.get('exit_code')}"
+                )
+
+            dur = duration_seconds(actual.get("start"), actual.get("end"))
+            if dur is not None and dur < 0:
+                status = "warning"
+                problems.append("negative_duration")
+                logger.warning(f"Negative duration for archive={keyword}, command={name}")
+
+            event = {
+                **base,
+                "event_type": "orc_command_validation",
+                "archive_keyword": keyword,
+                "command_name": name,
+                "tool": actual.get("tool"),
+                "start": actual.get("start"),
+                "end": actual.get("end"),
+                "duration_seconds": dur,
+                "exit_code": actual.get("exit_code"),
+                "pid": actual.get("pid"),
+                "sha1": actual.get("sha1"),
+                "status": status,
+                "status_code": status_code(status),
+                "issues": problems,
+            }
+            events.append(event)
+
+            for p in problems:
+                issues.append(
+                    {
+                        **base,
+                        "event_type": "orc_validation_issue",
+                        "archive_keyword": keyword,
+                        "command_name": name,
+                        "severity": status,
+                        "issue_code": p,
+                        "status": status,
+                        "status_code": status_code(status),
+                    }
+                )
+
+    return events, issues
+
+
+def emit_outline_system_events(outline: dict, outcome: dict, logger: logging.Logger) -> list[dict]:
+    base = emit_base_fields(outline, outcome, "orc_outcome")
+    events = []
+
+    system = outline.get("system", {})
+    if not system:
+        logger.info("No outline.system block found")
+        return events
+
+    logger.info("Emitting system inventory from outline.system")
+    os_info = system.get("operating_system", {})
+    mem = system.get("physical_memory", {})
+    tz = os_info.get("time_zone", {})
+
+    events.append(
+        {
+            **base,
+            "event_type": "orc_system_summary",
+            "system_name": system.get("name"),
+            "system_fullname": system.get("fullname"),
+            "system_role_type": system.get("type"),
+            "codepage": system.get("codepage"),
+            "codepage_name": system.get("codepage_name"),
+            "hypervisor": system.get("hypervisor"),
+            "architecture": system.get("architecture"),
+            "os_description": os_info.get("description"),
+            "os_version": os_info.get("version"),
+            "os_locale": os_info.get("locale"),
+            "os_language": os_info.get("language"),
+            "os_install_date": os_info.get("install_date"),
+            "os_install_time": os_info.get("install_time"),
+            "os_shutdown_time": os_info.get("shutdown_time"),
+            "os_tags": os_info.get("tag", []),
+            "timezone_daylight": tz.get("daylight"),
+            "timezone_standard": tz.get("standard"),
+            "timezone_current": tz.get("current"),
+            "timezone_current_bias": tz.get("current_bias"),
+            "memory_current_load": mem.get("current_load"),
+            "memory_physical": mem.get("physical"),
+            "memory_pagefile": mem.get("pagefile"),
+            "memory_available_physical": mem.get("available_physical"),
+            "memory_available_pagefile": mem.get("available_pagefile"),
+            "status": "ok",
+            "status_code": 0,
+        }
+    )
+
+    for cpu in system.get("cpu", []):
+        events.append(
+            {
+                **base,
+                "event_type": "orc_system_cpu",
+                "manufacturer": cpu.get("manufacturer"),
+                "name": cpu.get("name"),
+                "physical_processors": cpu.get("physical_processors"),
+                "logical_processors": cpu.get("logical_processors"),
+                "hyperthreading": cpu.get("hyperthreading"),
+                "status": "ok",
+                "status_code": 0,
+            }
+        )
+
+    for drive in system.get("physical_drives", []):
+        events.append(
+            {
+                **base,
+                "event_type": "orc_system_drive",
+                "path": drive.get("path"),
+                "type": drive.get("type"),
+                "serial": drive.get("serial"),
+                "size": drive.get("size"),
+                "drive_status": drive.get("status"),
+                "status": "ok",
+                "status_code": 0,
+            }
+        )
+
+    for vol in system.get("mounted_volumes", []):
+        events.append(
+            {
+                **base,
+                "event_type": "orc_system_volume",
+                "path": vol.get("path"),
+                "label": vol.get("label"),
+                "serial": vol.get("serial"),
+                "file_system": vol.get("file_system"),
+                "device_id": vol.get("device_id"),
+                "is_boot": vol.get("is_boot"),
+                "is_system": vol.get("is_system"),
+                "size": vol.get("size"),
+                "freespace": vol.get("freespace"),
+                "volume_type": vol.get("type"),
+                "status": "ok",
+                "status_code": 0,
+            }
+        )
+
+    network = system.get("network", {})
+    for adapter in network.get("adapter", []):
+        events.append(
+            {
+                **base,
+                "event_type": "orc_system_network_adapter",
+                "adapter_name": adapter.get("name"),
+                "friendly_name": adapter.get("friendly_name"),
+                "description": adapter.get("description"),
+                "physical": adapter.get("physical"),
+                "dns_suffix": adapter.get("dns_suffix"),
+                "dns_server": adapter.get("dns_server", []),
+                "addresses": adapter.get("address", []),
+                "status": "ok",
+                "status_code": 0,
+            }
+        )
+
+    for qfe in os_info.get("qfe", []):
+        events.append(
+            {
+                **base,
+                "event_type": "orc_system_hotfix",
+                "hotfix_id": qfe.get("hotfix_id"),
+                "installed_on": qfe.get("installed_on"),
+                "status": "ok",
+                "status_code": 0,
+            }
+        )
+
+    profile_list = outline.get("profile_list", {})
+    events.append(
+        {
+            **base,
+            "event_type": "orc_profile_summary",
+            "default_profile": profile_list.get("default_profile"),
+            "profiles_directory": profile_list.get("profiles_directory"),
+            "program_data": profile_list.get("program_data"),
+            "public_path": profile_list.get("public_path"),
+            "status": "ok",
+            "status_code": 0,
+        }
+    )
+
+    for profile in profile_list.get("profile", []):
+        events.append(
+            {
+                **base,
+                "event_type": "orc_profile",
+                "sid": profile.get("sid"),
+                "path": profile.get("path"),
+                "user": profile.get("user"),
+                "local_load_time": profile.get("local_load_time"),
+                "local_unload_time": profile.get("local_unload_time"),
+                "key_last_write": profile.get("key_last_write"),
+                "status": "ok",
+                "status_code": 0,
+            }
+        )
+
+    return events
+
+
+def xml_local_name(tag: str) -> str:
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def find_xml_candidates_from_outcome(outcome: dict, logger: logging.Logger) -> list[dict]:
+    candidates = []
+
+    for cs in outcome.get("command_set", []):
+        archive_keyword = cs.get("name")
+        for f in cs.get("archive", {}).get("files", []):
+            name = f.get("name", "")
+            lname = name.lower()
+            if lname == "config.xml" or lname.endswith("_cli_config.xml"):
+                candidates.append(
+                    {
+                        "archive_keyword": archive_keyword,
+                        "xml_name": name,
+                        "xml_name_lower": lname,
+                        "size_outcome": f.get("size"),
+                    }
+                )
+
+    logger.info(f"Found {len(candidates)} XML candidates from outcome inventory")
+    return candidates
+
+
+def resolve_xml_path(
+    extracted_root: Path,
+    archive_keyword: str,
+    xml_name: str,
+    logger: logging.Logger,
+) -> Path | None:
+    if not extracted_root.exists():
+        return None
+
+    keyword_lower = (archive_keyword or "").lower()
+    archive_dir = None
+
+    for child in extracted_root.iterdir():
+        if child.is_dir() and child.name.lower() == keyword_lower:
+            archive_dir = child
+            break
+
+    search_roots = []
+    if archive_dir:
+        search_roots.append(archive_dir)
+    search_roots.append(extracted_root)
+
+    xml_name_lower = xml_name.lower()
+
+    for root in search_roots:
+        for p in root.rglob("*"):
+            if p.is_file() and p.name.lower() == xml_name_lower:
+                logger.debug(f"Resolved XML {xml_name} to {p}")
+                return p
+
+    logger.warning(f"Could not resolve XML on disk: archive={archive_keyword}, xml={xml_name}")
+    return None
+
+
+def parse_config_xml_limits(root: ET.Element) -> dict:
+    limits = {
+        "limit_timeout_seconds": None,
+        "limit_max_file_count": None,
+        "limit_max_file_size_bytes": None,
+        "limit_max_total_size_bytes": None,
+    }
+
+    for elem in root.iter():
+        name = xml_local_name(elem.tag)
+
+        if name == "restrictions":
+            elapsed = elem.attrib.get("ElapsedTimeLimit")
+            if elapsed is not None:
+                try:
+                    limits["limit_timeout_seconds"] = int(elapsed)
+                except ValueError:
+                    pass
+
+        if name == "samples":
+            max_per_sample = elem.attrib.get("MaxPerSampleBytes")
+            max_total = elem.attrib.get("MaxTotalBytes")
+            max_count = elem.attrib.get("MaxSampleCount")
+
+            parsed = parse_size_to_bytes(max_per_sample)
+            if parsed is not None:
+                limits["limit_max_file_size_bytes"] = parsed
+
+            parsed = parse_size_to_bytes(max_total)
+            if parsed is not None:
+                limits["limit_max_total_size_bytes"] = parsed
+
+            if max_count and str(max_count).upper() != "N/A":
+                try:
+                    limits["limit_max_file_count"] = int(max_count)
+                except ValueError:
+                    pass
+
+    return limits
+
+
+def parse_command_outputs_from_config(root: ET.Element) -> dict[tuple[str, str], list[dict]]:
+    result = defaultdict(list)
+
+    for archive in root.findall(".//archive"):
+        archive_keyword = archive.attrib.get("keyword")
+        if not archive_keyword:
+            continue
+
+        for command in archive.findall("./command"):
+            command_keyword = command.attrib.get("keyword")
+            if not command_keyword:
+                continue
+
+            for output in command.findall("./output"):
+                name = output.attrib.get("name")
+                source = output.attrib.get("source")
+                if not name:
+                    continue
+
+                result[(archive_keyword.lower(), command_keyword.lower())].append(
+                    {
+                        "name_raw": name,
+                        "source": source,
+                    }
+                )
+
+    return result
+
+
+def map_outline_command_to_config_keyword(outline: dict) -> dict[tuple[str, str], str]:
+    mapping = {}
+    for archive in outline.get("archives", []):
+        archive_keyword = (archive.get("keyword") or "").lower()
+        for cmd in archive.get("commands", []):
+            outline_name = (cmd.get("name") or "").lower()
+            config_keyword = (cmd.get("keyword") or cmd.get("name") or "").lower()
+            if archive_keyword and outline_name and config_keyword:
+                mapping[(archive_keyword, outline_name)] = config_keyword
+    return mapping
+
+
+def parse_command_log_observations(log_path: Path, logger: logging.Logger) -> dict:
+    observations = {
+        "no_limits": None,
+        "observed_file_count": None,
+        "observed_max_file_size_bytes": None,
+        "observed_total_size_bytes": None,
+        "observed_duration_seconds": None,
+        "log_start": None,
+        "log_finish": None,
+        "matched_files": [],
+    }
+
+    size_values = []
+    matched_count = 0
+
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        logger.exception(f"Unable to read log file: {log_path}")
+        return observations
+
+    m = re.search(r"^\s*NoLimits:\s*(True|False)\s*$", text, flags=re.MULTILINE | re.IGNORECASE)
+    if m:
+        observations["no_limits"] = m.group(1).lower() == "true"
+
+    m = re.search(r"^\s*Start time:\s*([0-9T:\-\.Z]+)\s*$", text, flags=re.MULTILINE)
+    if m:
+        observations["log_start"] = m.group(1)
+
+    m = re.search(r"^\s*Finish time:\s*([0-9T:\-\.Z]+)\s*$", text, flags=re.MULTILINE)
+    if m:
+        observations["log_finish"] = m.group(1)
+
+    if observations["log_start"] and observations["log_finish"]:
+        observations["observed_duration_seconds"] = duration_seconds(
+            observations["log_start"], observations["log_finish"]
+        )
+
+    for m in re.finditer(r"^(.+?) matched \(([0-9]+) bytes\)\s*$", text, flags=re.MULTILINE):
+        path_text = m.group(1).strip()
+        size_val = int(m.group(2))
+        matched_count += 1
+        size_values.append(size_val)
+        observations["matched_files"].append(
+            {
+                "path": path_text,
+                "size_bytes": size_val,
+            }
+        )
+
+    if matched_count > 0:
+        observations["observed_file_count"] = matched_count
+        observations["observed_max_file_size_bytes"] = max(size_values)
+        observations["observed_total_size_bytes"] = sum(size_values)
+
+    items_lines = re.findall(
+        r"items:\s*([0-9]+)/([0-9]+)",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if observations["observed_file_count"] is None and items_lines:
+        try:
+            observations["observed_file_count"] = max(int(x[0]) for x in items_lines)
+        except Exception:
+            pass
+
+    return observations
+
+
+def is_config_file_name(name: str) -> bool:
+    lname = (name or "").lower()
+    return lname == "config.xml" or lname.endswith("_cli_config.xml")
+
+
+def output_role(name: str, source: str | None) -> str:
+    """
+    Classify an output from Config.xml.
+
+    collected:
+      - File
+      - StdOut
+      - StdOutErr when materialized into a real artifact file (.txt/.csv/.xml/.json/.out/.7z)
+
+    support:
+      - StdErr
+      - *.err
+      - *.getthis
+      - config xml
+      - *.log when produced from StdErr/StdOutErr
+
+    unknown:
+      - anything else
+    """
+    lname = (name or "").lower()
+    src = (source or "").strip().lower()
+
+    if is_config_file_name(lname):
+        return "support"
+    if lname.endswith(".err") or lname.endswith(".getthis"):
+        return "support"
+
+    if src == "file":
+        return "collected"
+    if src == "stdout":
+        return "collected"
+    if src == "stderr":
+        return "support"
+
+    if src == "stdouterr":
+        if lname.endswith(".log"):
+            return "support"
+        if any(
+            lname.endswith(ext)
+            for ext in (".txt", ".csv", ".xml", ".json", ".out", ".7z")
+        ):
+            return "collected"
+        return "support"
+
+    return "unknown"
+
+
+def is_container_output_name(name: str) -> bool:
+    return (name or "").lower().endswith(".7z")
+
+
+def list_files_recursive(root: Path) -> list[Path]:
+    return [p for p in root.rglob("*") if p.is_file()]
+
+
+def resolve_extracted_artifact_path(
+    extracted_root: Path,
+    archive_keyword: str,
+    output_name_raw: str,
+    computer_name: str,
+    logger: logging.Logger,
+    outer_archive_name: str | None = None,
+) -> Path | None:
+    """
+    Map a collected output from config/outcome to the extracted artifact path on disk.
+
+    Examples:
+      event_{FullComputerName}.7z -> extracted_files/logs/event_vagrant-10/
+      samhive_{FullComputerName}.7z -> extracted_files/sam/samhive_vagrant-10/
+      autoruns_{FullComputerName}.csv -> extracted_files/external/autoruns_vagrant-10.csv
+    """
+    archive_dir = extracted_root / archive_keyword.lower()
+
+    if not archive_dir.exists() and outer_archive_name:
+        archive_tail = Path(outer_archive_name).stem.split("_")[-1]
+        archive_dir = extracted_root / archive_tail
+
+    if not archive_dir.exists():
+        logger.warning(f"Archive extracted dir not found: {archive_dir}")
+        return None
+
+    expected_name = normalize_filename(output_name_raw, computer_name)
+    expected_stem = Path(expected_name).stem.lower()
+
+    # 1) Exact file match
+    for p in archive_dir.rglob("*"):
+        if p.is_file() and p.name.lower() == expected_name:
+            return p
+
+    # 2) Exact directory match for extracted container content
+    for p in archive_dir.rglob("*"):
+        if p.is_dir() and p.name.lower() == expected_stem:
+            return p
+
+    # 3) Exact file stem match
+    for p in archive_dir.rglob("*"):
+        if p.is_file() and p.stem.lower() == expected_stem:
+            return p
+
+    # 4) Prefix fallback
+    prefix_matches = []
+    for p in archive_dir.rglob("*"):
+        name_l = p.name.lower()
+        stem_l = p.stem.lower()
+        if name_l.startswith(expected_stem) or stem_l.startswith(expected_stem):
+            prefix_matches.append(p)
+
+    if is_container_output_name(output_name_raw):
+        dir_matches = [p for p in prefix_matches if p.is_dir()]
+        if dir_matches:
+            dir_matches.sort(key=lambda x: (len(str(x.parts)), str(x)))
+            return dir_matches[0]
+
+    if prefix_matches:
+        prefix_matches.sort(key=lambda x: (0 if x.is_file() else 1, len(str(x.parts)), str(x)))
+        return prefix_matches[0]
+
+    logger.warning(
+        f"Could not resolve extracted artifact path: archive={archive_keyword}, output={output_name_raw}"
+    )
+    return None
+
+
+def collect_main_output_disk_metrics(
+    extracted_root: Path,
+    archive_keyword: str,
+    output_name_raw: str,
+    computer_name: str,
+    logger: logging.Logger,
+    outer_archive_name: str | None = None,
+) -> dict:
+    resolved = resolve_extracted_artifact_path(
+        extracted_root=extracted_root,
+        archive_keyword=archive_keyword,
+        output_name_raw=output_name_raw,
+        computer_name=computer_name,
+        logger=logger,
+        outer_archive_name=outer_archive_name,
+    )
+
+    result = {
+        "resolved_disk_path": str(resolved) if resolved else None,
+        "present_on_disk": resolved is not None,
+        "disk_collected_file_count": None,
+        "disk_collected_total_size": None,
+        "disk_collected_max_file_size": None,
+    }
+
+    if not resolved:
+        return result
+
+    if resolved.is_file():
+        size = resolved.stat().st_size
+        result["disk_collected_file_count"] = 1
+        result["disk_collected_total_size"] = size
+        result["disk_collected_max_file_size"] = size
+        return result
+
+    files = list_files_recursive(resolved)
+    if not files:
+        result["disk_collected_file_count"] = 0
+        result["disk_collected_total_size"] = 0
+        result["disk_collected_max_file_size"] = 0
+        return result
+
+    sizes = [f.stat().st_size for f in files]
+    result["disk_collected_file_count"] = len(files)
+    result["disk_collected_total_size"] = sum(sizes)
+    result["disk_collected_max_file_size"] = max(sizes)
+    return result
+
+
+def evaluate_limits(
+    limit_timeout_seconds,
+    limit_max_file_count,
+    limit_max_file_size_bytes,
+    limit_max_total_size_bytes,
+    observed_duration_seconds,
+    observed_file_count,
+    observed_max_file_size_bytes,
+    observed_total_size_bytes,
+):
+    triggered_limits = []
+    reasons = []
+
+    if limit_timeout_seconds is not None:
+        if observed_duration_seconds is None:
+            reasons.append("missing observed duration for timeout evaluation")
+        elif observed_duration_seconds >= limit_timeout_seconds:
+            triggered_limits.append("timeout")
+
+    if limit_max_file_count is not None:
+        if observed_file_count is None:
+            reasons.append("missing observed file count for max file count evaluation")
+        elif observed_file_count >= limit_max_file_count:
+            triggered_limits.append("max_file_count")
+
+    if limit_max_file_size_bytes is not None:
+        if observed_max_file_size_bytes is None:
+            reasons.append("missing observed file sizes for max file size evaluation")
+        elif observed_max_file_size_bytes >= limit_max_file_size_bytes:
+            triggered_limits.append("max_file_size")
+
+    if limit_max_total_size_bytes is not None:
+        if observed_total_size_bytes is None:
+            reasons.append("missing observed total size for max total size evaluation")
+        elif observed_total_size_bytes >= limit_max_total_size_bytes:
+            triggered_limits.append("max_total_size")
+
+    return triggered_limits, reasons
+
+
+def reason_join(parts: list[str]) -> str | None:
+    parts = [p for p in parts if p]
+    if not parts:
+        return None
+    return "; ".join(parts)
+
+
+def parse_orc_artifact_evaluations(
+    outline: dict,
+    outcome: dict,
+    run_dir: Path,
+    disk_index: dict[str, list[dict]],
+    logger: logging.Logger,
+) -> tuple[list[dict], list[dict]]:
+    base = emit_base_fields(outline, outcome, "orc_outcome")
+    events = []
+    issues = []
+
+    logger.info("Building ORC collected artifact evaluation events")
+
+    extracted_root = run_dir / "extracted_files"
+    candidates = find_xml_candidates_from_outcome(outcome, logger)
+    outcome_file_index, _, command_index = build_outcome_inventory(outcome, logger)
+    command_name_to_config_keyword = map_outline_command_to_config_keyword(outline)
+
+    config_limits_by_archive_command = {}
+    config_outputs_by_archive_command = defaultdict(list)
+    cli_limits_by_archive = {}
+    cli_limits_by_archive_command = {}
+
+    # Parse XML files referenced by outcome
+    for candidate in candidates:
+        archive_keyword = candidate["archive_keyword"]
+        xml_name = candidate["xml_name"]
+        xml_path = resolve_xml_path(extracted_root, archive_keyword, xml_name, logger)
+
+        if not xml_path:
+            issues.append(
+                {
+                    **base,
+                    "event_type": "orc_validation_issue",
+                    "archive_keyword": archive_keyword,
+                    "expected_file_name": xml_name,
+                    "severity": "warning",
+                    "issue_code": "xml_file_missing_on_disk",
+                    "status": "warning",
+                    "status_code": 1,
+                }
+            )
+            continue
+
+        try:
+            tree = ET.parse(xml_path)
+            root = tree.getroot()
+        except Exception as exc:
+            logger.exception(f"Failed to parse XML: {xml_path}")
+            issues.append(
+                {
+                    **base,
+                    "event_type": "orc_validation_issue",
+                    "archive_keyword": archive_keyword,
+                    "expected_file_name": xml_name,
+                    "severity": "error",
+                    "issue_code": "xml_parse_error",
+                    "xml_error": str(exc),
+                    "status": "error",
+                    "status_code": 2,
+                }
+            )
+            continue
+
+        lname = xml_name.lower()
+
+        # Use the first global Config.xml as authoritative source for outputs and archive restrictions
+        if lname == "config.xml":
+            if config_outputs_by_archive_command:
+                continue
+
+            outputs_map = parse_command_outputs_from_config(root)
+            for key, value in outputs_map.items():
+                config_outputs_by_archive_command[key].extend(value)
+
+            for archive in root.findall(".//archive"):
+                archive_kw = (archive.attrib.get("keyword") or "").lower()
+                limits = parse_config_xml_limits(archive)
+
+                for command in archive.findall("./command"):
+                    cmd_kw = (command.attrib.get("keyword") or "").lower()
+                    if archive_kw and cmd_kw:
+                        config_limits_by_archive_command[(archive_kw, cmd_kw)] = limits.copy()
+
+        elif lname.endswith("_cli_config.xml"):
+            limits = parse_config_xml_limits(root)
+            cli_limits_by_archive.setdefault(archive_keyword.lower(), []).append(
+                {
+                    "xml_name": xml_name,
+                    "xml_path": str(xml_path),
+                    "limits": limits,
+                }
+            )
+
+    computer_name = outcome.get("computer_name") or outline.get("computer_name") or ""
+
+    # Associate CLI XMLs to outline commands by matching declared output names
+    for archive in outline.get("archives", []):
+        archive_keyword = archive.get("keyword")
+        archive_kw_lower = (archive_keyword or "").lower()
+
+        for cmd in archive.get("commands", []):
+            outline_command_name = cmd.get("name")
+            outline_command_name_lower = (outline_command_name or "").lower()
+
+            for out in cmd.get("output", []):
+                out_name_raw = out.get("name", "")
+                normalized_expected = normalize_filename(out_name_raw, computer_name)
+
+                for cli_entry in cli_limits_by_archive.get(archive_kw_lower, []):
+                    xml_name = cli_entry["xml_name"]
+                    xml_lname = xml_name.lower()
+
+                    if normalized_expected and normalized_expected in xml_lname:
+                        cli_limits_by_archive_command[(archive_kw_lower, outline_command_name_lower)] = {
+                            "xml_name": xml_name,
+                            "xml_path": cli_entry["xml_path"],
+                            **cli_entry["limits"],
+                        }
+
+    for archive in outline.get("archives", []):
+        archive_keyword = archive.get("keyword")
+        archive_kw_lower = (archive_keyword or "").lower()
+
+        outer_archive_name = archive.get("file")
+        outer_archive_present_on_disk = None
+        outer_archive_size_disk = None
+        outer_archive_size_outcome = None
+
+        if outer_archive_name:
+            outer_archive_path = run_dir / outer_archive_name
+            outer_archive_present_on_disk = outer_archive_path.exists()
+            outer_archive_size_disk = outer_archive_path.stat().st_size if outer_archive_present_on_disk else None
+
+        for cs in outcome.get("command_set", []):
+            if cs.get("name") == archive_keyword:
+                outer_archive_size_outcome = cs.get("archive", {}).get("size")
+                break
+
+        for cmd in archive.get("commands", []):
+            command_name = cmd.get("name")
+            command_name_lower = (command_name or "").lower()
+
+            config_command_keyword_lower = command_name_to_config_keyword.get(
+                (archive_kw_lower, command_name_lower),
+                command_name_lower,
+            )
+
+            # Prefer outputs declared in Config.xml, fallback to outline outputs
+            command_outputs = config_outputs_by_archive_command.get(
+                (archive_kw_lower, config_command_keyword_lower),
+                [],
+            )
+            if not command_outputs:
+                command_outputs = [
+                    {
+                        "name_raw": out.get("name", ""),
+                        "source": out.get("source"),
+                    }
+                    for out in cmd.get("output", [])
+                ]
+
+            # Use Config.xml source + output name to determine collected artifacts.
+            collected_outputs = [
+                {
+                    "name_raw": out.get("name_raw"),
+                    "source": out.get("source"),
+                }
+                for out in command_outputs
+                if output_role(out.get("name_raw", ""), out.get("source")) == "collected"
+            ]
+
+            support_outputs = [
+                {
+                    "name_raw": out.get("name_raw"),
+                    "source": out.get("source"),
+                }
+                for out in command_outputs
+                if output_role(out.get("name_raw", ""), out.get("source")) == "support"
+            ]
+
+            main_output = collected_outputs[0] if collected_outputs else None
+
+            collected_name_raw = main_output["name_raw"] if main_output else None
+            collected_name_expected = (
+                normalize_filename(collected_name_raw, computer_name) if collected_name_raw else None
+            )
+
+            collected_present_in_outcome = False
+            collected_size_outcome = None
+            if collected_name_expected:
+                outcome_hits = outcome_file_index.get(collected_name_expected, [])
+                if outcome_hits:
+                    collected_present_in_outcome = True
+                    collected_size_outcome = outcome_hits[0].get("size")
+
+            config_limits = config_limits_by_archive_command.get(
+                (archive_kw_lower, config_command_keyword_lower),
+                {}
+            )
+            cli_limits = cli_limits_by_archive_command.get((archive_kw_lower, command_name_lower), {})
+
+            limit_timeout_seconds = cli_limits.get("limit_timeout_seconds")
+            if limit_timeout_seconds is None:
+                limit_timeout_seconds = config_limits.get("limit_timeout_seconds")
+
+            limit_max_file_count = cli_limits.get("limit_max_file_count")
+            if limit_max_file_count is None:
+                limit_max_file_count = config_limits.get("limit_max_file_count")
+
+            limit_max_file_size_bytes = cli_limits.get("limit_max_file_size_bytes")
+            if limit_max_file_size_bytes is None:
+                limit_max_file_size_bytes = config_limits.get("limit_max_file_size_bytes")
+
+            limit_max_total_size_bytes = cli_limits.get("limit_max_total_size_bytes")
+            if limit_max_total_size_bytes is None:
+                limit_max_total_size_bytes = config_limits.get("limit_max_total_size_bytes")
+
+            config_source = cli_limits.get("xml_name")
+            if not config_source and config_limits:
+                config_source = "Config.xml"
+
+            outcome_cmd = command_index.get((archive_keyword, command_name))
+            observed_duration_seconds = None
+            if outcome_cmd:
+                observed_duration_seconds = duration_seconds(
+                    outcome_cmd.get("start"),
+                    outcome_cmd.get("end"),
+                )
+
+            log_source = None
+            log_observations = None
+
+            # Find one support log for extra observations
+            possible_logs = []
+            for out in support_outputs:
+                expected_name = normalize_filename(out.get("name_raw", ""), computer_name)
+                possible_logs.append(expected_name)
+
+            for log_name in possible_logs:
+                hits_log = disk_index.get(log_name, [])
+                if hits_log:
+                    log_path = Path(hits_log[0]["path"])
+                    log_source = log_path.name
+                    log_observations = parse_command_log_observations(log_path, logger)
+                    break
+
+            if observed_duration_seconds is None and log_observations and log_observations.get("observed_duration_seconds") is not None:
+                observed_duration_seconds = log_observations["observed_duration_seconds"]
+
+            no_limits = log_observations.get("no_limits") if log_observations else None
+
+            disk_metrics = {
+                "resolved_disk_path": None,
+                "present_on_disk": False,
+                "disk_collected_file_count": None,
+                "disk_collected_total_size": None,
+                "disk_collected_max_file_size": None,
+            }
+            if collected_name_raw:
+                disk_metrics = collect_main_output_disk_metrics(
+                    extracted_root=extracted_root,
+                    archive_keyword=archive_keyword,
+                    output_name_raw=collected_name_raw,
+                    computer_name=computer_name,
+                    logger=logger,
+                    outer_archive_name=outer_archive_name,
+                )
+
+            observed_file_count = disk_metrics["disk_collected_file_count"]
+            observed_total_size_bytes = disk_metrics["disk_collected_total_size"]
+            observed_max_file_size_bytes = disk_metrics["disk_collected_max_file_size"]
+
+            # Fallback to log-derived observations only if main disk metrics are absent
+            if observed_file_count is None and log_observations and log_observations.get("observed_file_count") is not None:
+                observed_file_count = log_observations["observed_file_count"]
+
+            if observed_max_file_size_bytes is None and log_observations and log_observations.get("observed_max_file_size_bytes") is not None:
+                observed_max_file_size_bytes = log_observations["observed_max_file_size_bytes"]
+
+            if observed_total_size_bytes is None and log_observations and log_observations.get("observed_total_size_bytes") is not None:
+                observed_total_size_bytes = log_observations["observed_total_size_bytes"]
+
+            triggered_limits, eval_reasons = evaluate_limits(
+                limit_timeout_seconds=limit_timeout_seconds,
+                limit_max_file_count=limit_max_file_count,
+                limit_max_file_size_bytes=limit_max_file_size_bytes,
+                limit_max_total_size_bytes=limit_max_total_size_bytes,
+                observed_duration_seconds=observed_duration_seconds,
+                observed_file_count=observed_file_count,
+                observed_max_file_size_bytes=observed_max_file_size_bytes,
+                observed_total_size_bytes=observed_total_size_bytes,
+            )
+
+            reason_parts = []
+
+            if triggered_limits:
+                status = "error"
+                reason_parts.append("configured limit reached")
+            elif collected_name_raw and not collected_present_in_outcome:
+                status = "warning"
+                reason_parts.append("collected artifact missing in outcome")
+            elif collected_name_raw and not disk_metrics["present_on_disk"]:
+                status = "warning"
+                reason_parts.append("collected artifact missing on disk")
+            elif eval_reasons and any(
+                v is not None for v in [
+                    limit_timeout_seconds,
+                    limit_max_file_count,
+                    limit_max_file_size_bytes,
+                    limit_max_total_size_bytes,
+                ]
+            ):
+                status = "warning"
+                reason_parts.extend(eval_reasons)
+            elif no_limits is True:
+                status = "ok"
+                reason_parts.append("no limits enabled")
+            else:
+                status = "ok"
+
+            events.append(
+                {
+                    **base,
+                    "event_type": "orc_artifact_evaluation",
+                    "archive_keyword": archive_keyword,
+                    "command_name": command_name,
+                    "outer_archive_name": outer_archive_name,
+                    "outer_archive_present_on_disk": outer_archive_present_on_disk,
+                    "outer_archive_size_disk": outer_archive_size_disk,
+                    "outer_archive_size_outcome": outer_archive_size_outcome,
+                    "config_source": config_source,
+                    "log_source": log_source,
+                    "collected_name_raw": collected_name_raw,
+                    "collected_name_expected": collected_name_expected,
+                    "collected_present_in_outcome": collected_present_in_outcome,
+                    "collected_size_outcome": collected_size_outcome,
+                    "collected_resolved_disk_path": disk_metrics["resolved_disk_path"],
+                    "collected_present_on_disk": disk_metrics["present_on_disk"],
+                    "observed_duration_seconds": observed_duration_seconds,
+                    "disk_collected_file_count": observed_file_count,
+                    "disk_collected_total_size": observed_total_size_bytes,
+                    "disk_collected_max_file_size": observed_max_file_size_bytes,
+                    "limit_timeout_seconds": limit_timeout_seconds,
+                    "limit_max_file_count": limit_max_file_count,
+                    "limit_max_file_size_bytes": limit_max_file_size_bytes,
+                    "limit_max_total_size_bytes": limit_max_total_size_bytes,
+                    "triggered_limits": triggered_limits,
+                    "status": status,
+                    "status_code": status_code(status),
+                    "reason": reason_join(reason_parts),
+                }
+            )
+
+    logger.info(f"Built {len(events)} collected artifact evaluation events")
+    return events, issues
+
+
+def write_jsonl(path: Path, records: list[dict], logger: logging.Logger) -> None:
+    logger.info(f"Writing {len(records)} records to {path}")
+    with path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-dir", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logger = setup_logger(args.verbose)
+
+    try:
+        run_dir = Path(args.input_dir)
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"Starting orc_outcome on: {run_dir}")
+
+        outcome_path = find_single_json(run_dir, "outcome", logger)
+        outline_path = find_single_json(run_dir, "outline", logger)
+
+        outcome_data = load_json(outcome_path, logger)
+        outline_data = load_json(outline_path, logger)
+
+        outcome = get_outcome(outcome_data)
+        outline = get_outline(outline_data)
+
+        disk_index = build_disk_index(run_dir, logger)
+        records = []
+
+        records.append(build_run_summary(outline, outcome, disk_index))
+
+        archive_events, archive_issues = validate_archives(outline, outcome, run_dir, logger)
+        command_events, command_issues = validate_commands(outline, outcome, logger)
+        system_events = emit_outline_system_events(outline, outcome, logger)
+        artifact_events, artifact_issues = parse_orc_artifact_evaluations(
+            outline=outline,
+            outcome=outcome,
+            run_dir=run_dir,
+            disk_index=disk_index,
+            logger=logger,
+        )
+
+        records.extend(archive_events)
+        records.extend(command_events)
+        records.extend(system_events)
+        records.extend(artifact_events)
+        records.extend(archive_issues)
+        records.extend(command_issues)
+        records.extend(artifact_issues)
+
+        computer_name = outcome.get("computer_name") or outline.get("computer_name") or run_dir.name
+        ts = outcome.get("timestamp") or outline.get("timestamp") or "unknown"
+        out_file = output_dir / f"orc_outcome_{computer_name}_{ts}.jsonl"
+        write_jsonl(out_file, records, logger)
+
+        logger.info("orc_outcome completed successfully")
+
+    except Exception:
+        logger.exception("orc_outcome failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/OSIR/bin/orc_outcome.py
+++ b/OSIR/bin/orc_outcome.py
@@ -596,28 +596,6 @@ def xml_local_name(tag: str) -> str:
     return tag
 
 
-def find_xml_candidates_from_outcome(outcome: dict, logger: logging.Logger) -> list[dict]:
-    candidates = []
-
-    for cs in outcome.get("command_set", []):
-        archive_keyword = cs.get("name")
-        for f in cs.get("archive", {}).get("files", []):
-            name = f.get("name", "")
-            lname = name.lower()
-            if lname == "config.xml" or lname.endswith("_cli_config.xml"):
-                candidates.append(
-                    {
-                        "archive_keyword": archive_keyword,
-                        "xml_name": name,
-                        "xml_name_lower": lname,
-                        "size_outcome": f.get("size"),
-                    }
-                )
-
-    logger.info(f"Found {len(candidates)} XML candidates from outcome inventory")
-    return candidates
-
-
 def resolve_xml_path(
     extracted_root: Path,
     archive_keyword: str,
@@ -805,7 +783,7 @@ def parse_command_log_observations(log_path: Path, logger: logging.Logger) -> di
 
 def is_config_file_name(name: str) -> bool:
     lname = (name or "").lower()
-    return lname == "config.xml" or lname.endswith("_cli_config.xml")
+    return lname == "config.xml" or "_cli_config.xml" in lname
 
 
 def output_role(name: str, source: str | None) -> str:
@@ -892,22 +870,18 @@ def resolve_extracted_artifact_path(
     expected_name = normalize_filename(output_name_raw, computer_name)
     expected_stem = Path(expected_name).stem.lower()
 
-    # 1) Exact file match
     for p in archive_dir.rglob("*"):
         if p.is_file() and p.name.lower() == expected_name:
             return p
 
-    # 2) Exact directory match for extracted container content
     for p in archive_dir.rglob("*"):
         if p.is_dir() and p.name.lower() == expected_stem:
             return p
 
-    # 3) Exact file stem match
     for p in archive_dir.rglob("*"):
         if p.is_file() and p.stem.lower() == expected_stem:
             return p
 
-    # 4) Prefix fallback
     prefix_matches = []
     for p in archive_dir.rglob("*"):
         name_l = p.name.lower()
@@ -999,18 +973,6 @@ def evaluate_limits(
         elif observed_duration_seconds >= limit_timeout_seconds:
             triggered_limits.append("timeout")
 
-    if limit_max_file_count is not None:
-        if observed_file_count is None:
-            reasons.append("missing observed file count for max file count evaluation")
-        elif observed_file_count >= limit_max_file_count:
-            triggered_limits.append("max_file_count")
-
-    if limit_max_file_size_bytes is not None:
-        if observed_max_file_size_bytes is None:
-            reasons.append("missing observed file sizes for max file size evaluation")
-        elif observed_max_file_size_bytes >= limit_max_file_size_bytes:
-            triggered_limits.append("max_file_size")
-
     if limit_max_total_size_bytes is not None:
         if observed_total_size_bytes is None:
             reasons.append("missing observed total size for max total size evaluation")
@@ -1027,6 +989,109 @@ def reason_join(parts: list[str]) -> str | None:
     return "; ".join(parts)
 
 
+def normalize_match_token(value: str) -> str:
+    value = (value or "").lower()
+    value = value.replace("{fullcomputername}", "")
+    value = value.replace("{computername}", "")
+    value = re.sub(r"_cli_config\.xml$", "", value)
+    value = re.sub(r"\.(7z|log|err|getthis|out|csv|json|txt|xml)$", "", value)
+    value = re.sub(r"[^a-z0-9]+", "", value)
+    return value
+
+
+def get_global_config_file_entry(command_set: dict) -> dict | None:
+    for f in command_set.get("archive", {}).get("files", []):
+        name = f.get("name", "")
+        if name.lower() == "config.xml":
+            return f
+    return None
+
+
+def get_cli_xml_file_entries(command_set: dict) -> list[dict]:
+    result = []
+    for f in command_set.get("archive", {}).get("files", []):
+        name = f.get("name", "")
+        lname = name.lower()
+        if lname != "config.xml" and "_cli_config.xml" in lname:
+            result.append(f)
+    return result
+
+
+def resolve_cli_xml_entry_for_command(
+    command_set: dict,
+    outline_command: dict,
+    outcome_command: dict | None,
+) -> dict | None:
+    cli_xmls = get_cli_xml_file_entries(command_set)
+    if not cli_xmls:
+        return None
+
+    candidate_tokens = []
+
+    def add_candidate(value: str | None):
+        token = normalize_match_token(value or "")
+        if token and token not in candidate_tokens:
+            candidate_tokens.append(token)
+
+    add_candidate(outline_command.get("name"))
+    add_candidate(outline_command.get("keyword"))
+
+    for out in outline_command.get("output", []):
+        add_candidate(out.get("name"))
+
+    if outcome_command:
+        add_candidate(outcome_command.get("name"))
+        for out in outcome_command.get("output", []):
+            add_candidate(out.get("name"))
+
+    xml_entries = []
+    for f in cli_xmls:
+        xml_name = f.get("name", "")
+        xml_token = normalize_match_token(xml_name)
+        xml_entries.append(
+            {
+                "entry": f,
+                "xml_token": xml_token,
+            }
+        )
+
+    for candidate in candidate_tokens:
+        for xml in xml_entries:
+            if candidate == xml["xml_token"]:
+                return xml["entry"]
+
+    for candidate in candidate_tokens:
+        for xml in xml_entries:
+            xml_token = xml["xml_token"]
+            if candidate.startswith(xml_token) or xml_token.startswith(candidate):
+                return xml["entry"]
+
+    if len(cli_xmls) == 1:
+        return cli_xmls[0]
+
+    return None
+
+
+def parse_xml_file_cached(
+    xml_path: Path,
+    xml_cache: dict[str, tuple[ET.Element | None, str | None]],
+    logger: logging.Logger,
+) -> tuple[ET.Element | None, str | None]:
+    cache_key = str(xml_path)
+    if cache_key in xml_cache:
+        return xml_cache[cache_key]
+
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        xml_cache[cache_key] = (root, None)
+        return root, None
+    except Exception as exc:
+        logger.exception(f"Failed to parse XML: {xml_path}")
+        xml_cache[cache_key] = (None, str(exc))
+        return None, str(exc)
+
+
 def parse_orc_artifact_evaluations(
     outline: dict,
     outcome: dict,
@@ -1041,115 +1106,20 @@ def parse_orc_artifact_evaluations(
     logger.info("Building ORC collected artifact evaluation events")
 
     extracted_root = run_dir / "extracted_files"
-    candidates = find_xml_candidates_from_outcome(outcome, logger)
-    outcome_file_index, _, command_index = build_outcome_inventory(outcome, logger)
+    outcome_file_index, archive_index, command_index = build_outcome_inventory(outcome, logger)
     command_name_to_config_keyword = map_outline_command_to_config_keyword(outline)
+    xml_cache: dict[str, tuple[ET.Element | None, str | None]] = {}
 
-    config_limits_by_archive_command = {}
-    config_outputs_by_archive_command = defaultdict(list)
-    cli_limits_by_archive = {}
-    cli_limits_by_archive_command = {}
-
-    # Parse XML files referenced by outcome
-    for candidate in candidates:
-        archive_keyword = candidate["archive_keyword"]
-        xml_name = candidate["xml_name"]
-        xml_path = resolve_xml_path(extracted_root, archive_keyword, xml_name, logger)
-
-        if not xml_path:
-            issues.append(
-                {
-                    **base,
-                    "event_type": "orc_validation_issue",
-                    "archive_keyword": archive_keyword,
-                    "expected_file_name": xml_name,
-                    "severity": "warning",
-                    "issue_code": "xml_file_missing_on_disk",
-                    "status": "warning",
-                    "status_code": 1,
-                }
-            )
-            continue
-
-        try:
-            tree = ET.parse(xml_path)
-            root = tree.getroot()
-        except Exception as exc:
-            logger.exception(f"Failed to parse XML: {xml_path}")
-            issues.append(
-                {
-                    **base,
-                    "event_type": "orc_validation_issue",
-                    "archive_keyword": archive_keyword,
-                    "expected_file_name": xml_name,
-                    "severity": "error",
-                    "issue_code": "xml_parse_error",
-                    "xml_error": str(exc),
-                    "status": "error",
-                    "status_code": 2,
-                }
-            )
-            continue
-
-        lname = xml_name.lower()
-
-        # Use the first global Config.xml as authoritative source for outputs and archive restrictions
-        if lname == "config.xml":
-            if config_outputs_by_archive_command:
-                continue
-
-            outputs_map = parse_command_outputs_from_config(root)
-            for key, value in outputs_map.items():
-                config_outputs_by_archive_command[key].extend(value)
-
-            for archive in root.findall(".//archive"):
-                archive_kw = (archive.attrib.get("keyword") or "").lower()
-                limits = parse_config_xml_limits(archive)
-
-                for command in archive.findall("./command"):
-                    cmd_kw = (command.attrib.get("keyword") or "").lower()
-                    if archive_kw and cmd_kw:
-                        config_limits_by_archive_command[(archive_kw, cmd_kw)] = limits.copy()
-
-        elif lname.endswith("_cli_config.xml"):
-            limits = parse_config_xml_limits(root)
-            cli_limits_by_archive.setdefault(archive_keyword.lower(), []).append(
-                {
-                    "xml_name": xml_name,
-                    "xml_path": str(xml_path),
-                    "limits": limits,
-                }
-            )
+    global_config_outputs_by_archive_command = defaultdict(list)
+    global_config_limits_by_archive_command = {}
+    global_config_parsed_archives = set()
 
     computer_name = outcome.get("computer_name") or outline.get("computer_name") or ""
 
-    # Associate CLI XMLs to outline commands by matching declared output names
     for archive in outline.get("archives", []):
         archive_keyword = archive.get("keyword")
         archive_kw_lower = (archive_keyword or "").lower()
-
-        for cmd in archive.get("commands", []):
-            outline_command_name = cmd.get("name")
-            outline_command_name_lower = (outline_command_name or "").lower()
-
-            for out in cmd.get("output", []):
-                out_name_raw = out.get("name", "")
-                normalized_expected = normalize_filename(out_name_raw, computer_name)
-
-                for cli_entry in cli_limits_by_archive.get(archive_kw_lower, []):
-                    xml_name = cli_entry["xml_name"]
-                    xml_lname = xml_name.lower()
-
-                    if normalized_expected and normalized_expected in xml_lname:
-                        cli_limits_by_archive_command[(archive_kw_lower, outline_command_name_lower)] = {
-                            "xml_name": xml_name,
-                            "xml_path": cli_entry["xml_path"],
-                            **cli_entry["limits"],
-                        }
-
-    for archive in outline.get("archives", []):
-        archive_keyword = archive.get("keyword")
-        archive_kw_lower = (archive_keyword or "").lower()
+        command_set = archive_index.get(archive_keyword)
 
         outer_archive_name = archive.get("file")
         outer_archive_present_on_disk = None
@@ -1161,10 +1131,59 @@ def parse_orc_artifact_evaluations(
             outer_archive_present_on_disk = outer_archive_path.exists()
             outer_archive_size_disk = outer_archive_path.stat().st_size if outer_archive_present_on_disk else None
 
-        for cs in outcome.get("command_set", []):
-            if cs.get("name") == archive_keyword:
-                outer_archive_size_outcome = cs.get("archive", {}).get("size")
-                break
+        if command_set:
+            outer_archive_size_outcome = command_set.get("archive", {}).get("size")
+
+        if archive_kw_lower not in global_config_parsed_archives and command_set:
+            global_config_parsed_archives.add(archive_kw_lower)
+            global_cfg_entry = get_global_config_file_entry(command_set)
+
+            if global_cfg_entry:
+                xml_name = global_cfg_entry.get("name")
+                xml_path = resolve_xml_path(extracted_root, archive_keyword, xml_name, logger)
+
+                if not xml_path:
+                    issues.append(
+                        {
+                            **base,
+                            "event_type": "orc_validation_issue",
+                            "archive_keyword": archive_keyword,
+                            "expected_file_name": xml_name,
+                            "severity": "warning",
+                            "issue_code": "xml_file_missing_on_disk",
+                            "status": "warning",
+                            "status_code": 1,
+                        }
+                    )
+                else:
+                    root, xml_error = parse_xml_file_cached(xml_path, xml_cache, logger)
+                    if root is None:
+                        issues.append(
+                            {
+                                **base,
+                                "event_type": "orc_validation_issue",
+                                "archive_keyword": archive_keyword,
+                                "expected_file_name": xml_name,
+                                "severity": "error",
+                                "issue_code": "xml_parse_error",
+                                "xml_error": xml_error,
+                                "status": "error",
+                                "status_code": 2,
+                            }
+                        )
+                    else:
+                        outputs_map = parse_command_outputs_from_config(root)
+                        for key, value in outputs_map.items():
+                            global_config_outputs_by_archive_command[key].extend(value)
+
+                        for archive_elem in root.findall(".//archive"):
+                            cfg_archive_kw = (archive_elem.attrib.get("keyword") or "").lower()
+                            limits = parse_config_xml_limits(archive_elem)
+
+                            for command_elem in archive_elem.findall("./command"):
+                                cmd_kw = (command_elem.attrib.get("keyword") or "").lower()
+                                if cfg_archive_kw and cmd_kw:
+                                    global_config_limits_by_archive_command[(cfg_archive_kw, cmd_kw)] = limits.copy()
 
         for cmd in archive.get("commands", []):
             command_name = cmd.get("name")
@@ -1175,8 +1194,9 @@ def parse_orc_artifact_evaluations(
                 command_name_lower,
             )
 
-            # Prefer outputs declared in Config.xml, fallback to outline outputs
-            command_outputs = config_outputs_by_archive_command.get(
+            outcome_cmd = command_index.get((archive_keyword, command_name))
+
+            command_outputs = global_config_outputs_by_archive_command.get(
                 (archive_kw_lower, config_command_keyword_lower),
                 [],
             )
@@ -1189,7 +1209,15 @@ def parse_orc_artifact_evaluations(
                     for out in cmd.get("output", [])
                 ]
 
-            # Use Config.xml source + output name to determine collected artifacts.
+            if not command_outputs and outcome_cmd:
+                command_outputs = [
+                    {
+                        "name_raw": out.get("name", ""),
+                        "source": out.get("source"),
+                    }
+                    for out in outcome_cmd.get("output", [])
+                ]
+
             collected_outputs = [
                 {
                     "name_raw": out.get("name_raw"),
@@ -1223,11 +1251,53 @@ def parse_orc_artifact_evaluations(
                     collected_present_in_outcome = True
                     collected_size_outcome = outcome_hits[0].get("size")
 
-            config_limits = config_limits_by_archive_command.get(
+            config_limits = global_config_limits_by_archive_command.get(
                 (archive_kw_lower, config_command_keyword_lower),
                 {}
             )
-            cli_limits = cli_limits_by_archive_command.get((archive_kw_lower, command_name_lower), {})
+
+            cli_limits = {}
+            cli_xml_name = None
+
+            if command_set:
+                cli_xml_entry = resolve_cli_xml_entry_for_command(command_set, cmd, outcome_cmd)
+                if cli_xml_entry:
+                    cli_xml_name = cli_xml_entry.get("name")
+                    cli_xml_path = resolve_xml_path(extracted_root, archive_keyword, cli_xml_name, logger)
+
+                    if not cli_xml_path:
+                        issues.append(
+                            {
+                                **base,
+                                "event_type": "orc_validation_issue",
+                                "archive_keyword": archive_keyword,
+                                "command_name": command_name,
+                                "expected_file_name": cli_xml_name,
+                                "severity": "warning",
+                                "issue_code": "xml_file_missing_on_disk",
+                                "status": "warning",
+                                "status_code": 1,
+                            }
+                        )
+                    else:
+                        root, xml_error = parse_xml_file_cached(cli_xml_path, xml_cache, logger)
+                        if root is None:
+                            issues.append(
+                                {
+                                    **base,
+                                    "event_type": "orc_validation_issue",
+                                    "archive_keyword": archive_keyword,
+                                    "command_name": command_name,
+                                    "expected_file_name": cli_xml_name,
+                                    "severity": "error",
+                                    "issue_code": "xml_parse_error",
+                                    "xml_error": xml_error,
+                                    "status": "error",
+                                    "status_code": 2,
+                                }
+                            )
+                        else:
+                            cli_limits = parse_config_xml_limits(root)
 
             limit_timeout_seconds = cli_limits.get("limit_timeout_seconds")
             if limit_timeout_seconds is None:
@@ -1245,11 +1315,10 @@ def parse_orc_artifact_evaluations(
             if limit_max_total_size_bytes is None:
                 limit_max_total_size_bytes = config_limits.get("limit_max_total_size_bytes")
 
-            config_source = cli_limits.get("xml_name")
+            config_source = cli_xml_name
             if not config_source and config_limits:
                 config_source = "Config.xml"
 
-            outcome_cmd = command_index.get((archive_keyword, command_name))
             observed_duration_seconds = None
             if outcome_cmd:
                 observed_duration_seconds = duration_seconds(
@@ -1260,11 +1329,19 @@ def parse_orc_artifact_evaluations(
             log_source = None
             log_observations = None
 
-            # Find one support log for extra observations
             possible_logs = []
             for out in support_outputs:
                 expected_name = normalize_filename(out.get("name_raw", ""), computer_name)
                 possible_logs.append(expected_name)
+
+            if outcome_cmd:
+                for out in outcome_cmd.get("output", []):
+                    out_name = out.get("name", "")
+                    out_source = out.get("source")
+                    if output_role(out_name, out_source) == "support":
+                        expected_name = normalize_filename(out_name, computer_name)
+                        if expected_name not in possible_logs:
+                            possible_logs.append(expected_name)
 
             for log_name in possible_logs:
                 hits_log = disk_index.get(log_name, [])
@@ -1274,7 +1351,11 @@ def parse_orc_artifact_evaluations(
                     log_observations = parse_command_log_observations(log_path, logger)
                     break
 
-            if observed_duration_seconds is None and log_observations and log_observations.get("observed_duration_seconds") is not None:
+            if (
+                observed_duration_seconds is None
+                and log_observations
+                and log_observations.get("observed_duration_seconds") is not None
+            ):
                 observed_duration_seconds = log_observations["observed_duration_seconds"]
 
             no_limits = log_observations.get("no_limits") if log_observations else None
@@ -1300,14 +1381,25 @@ def parse_orc_artifact_evaluations(
             observed_total_size_bytes = disk_metrics["disk_collected_total_size"]
             observed_max_file_size_bytes = disk_metrics["disk_collected_max_file_size"]
 
-            # Fallback to log-derived observations only if main disk metrics are absent
-            if observed_file_count is None and log_observations and log_observations.get("observed_file_count") is not None:
+            if (
+                observed_file_count is None
+                and log_observations
+                and log_observations.get("observed_file_count") is not None
+            ):
                 observed_file_count = log_observations["observed_file_count"]
 
-            if observed_max_file_size_bytes is None and log_observations and log_observations.get("observed_max_file_size_bytes") is not None:
+            if (
+                observed_max_file_size_bytes is None
+                and log_observations
+                and log_observations.get("observed_max_file_size_bytes") is not None
+            ):
                 observed_max_file_size_bytes = log_observations["observed_max_file_size_bytes"]
 
-            if observed_total_size_bytes is None and log_observations and log_observations.get("observed_total_size_bytes") is not None:
+            if (
+                observed_total_size_bytes is None
+                and log_observations
+                and log_observations.get("observed_total_size_bytes") is not None
+            ):
                 observed_total_size_bytes = log_observations["observed_total_size_bytes"]
 
             triggered_limits, eval_reasons = evaluate_limits(
@@ -1333,10 +1425,9 @@ def parse_orc_artifact_evaluations(
                 status = "warning"
                 reason_parts.append("collected artifact missing on disk")
             elif eval_reasons and any(
-                v is not None for v in [
+                v is not None
+                for v in [
                     limit_timeout_seconds,
-                    limit_max_file_count,
-                    limit_max_file_size_bytes,
                     limit_max_total_size_bytes,
                 ]
             ):

--- a/OSIR/configs/dependencies/ecs_normalize/windows/NTFSInfo.vrl
+++ b/OSIR/configs/dependencies/ecs_normalize/windows/NTFSInfo.vrl
@@ -159,7 +159,7 @@ if exists(.Attributes) {
 if exists(.CreationDate) {
   cd_raw = to_string!(del(.CreationDate))
   if cd_raw != "" {
-    cd = parse_timestamp(cd_raw, "%F %T%.f") ?? parse_timestamp(cd_raw, "%F %T") ?? null
+    cd = parse_timestamp(cd_raw, "%F %T%.f", "UTC") ?? parse_timestamp(cd_raw, "%F %T", "UTC") ?? null
     if cd != null {
       .file.ctime = cd
     } else {
@@ -172,7 +172,7 @@ if exists(.CreationDate) {
 if exists(.LastModificationDate) {
   lmd_raw = to_string!(del(.LastModificationDate))
   if lmd_raw != "" {
-    lmd = parse_timestamp(lmd_raw, "%F %T%.f") ?? parse_timestamp(lmd_raw, "%F %T") ?? null
+    lmd = parse_timestamp(lmd_raw, "%F %T%.f", "UTC") ?? parse_timestamp(lmd_raw, "%F %T", "UTC") ?? null
     if lmd != null {
       .file.mtime = lmd
     } else {
@@ -185,7 +185,7 @@ if exists(.LastModificationDate) {
 if exists(.LastAccessDate) {
   lad_raw = to_string!(del(.LastAccessDate))
   if lad_raw != "" {
-    lad = parse_timestamp(lad_raw, "%F %T%.f") ?? parse_timestamp(lad_raw, "%F %T") ?? null
+    lad = parse_timestamp(lad_raw, "%F %T%.f", "UTC") ?? parse_timestamp(lad_raw, "%F %T", "UTC") ?? null
     if lad != null {
       .file.atime = lad
     } else {
@@ -198,7 +198,7 @@ if exists(.LastAccessDate) {
 if exists(.LastAttrChangeDate) {
   lac_raw = to_string!(del(.LastAttrChangeDate))
   if lac_raw != "" {
-    lac = parse_timestamp(lac_raw, "%F %T%.f") ?? parse_timestamp(lac_raw, "%F %T") ?? null
+    lac = parse_timestamp(lac_raw, "%F %T%.f", "UTC") ?? parse_timestamp(lac_raw, "%F %T", "UTC") ?? null
     if lac != null {
       .file.Ext.ntfs.last_attr_change = lac
     } else {
@@ -214,7 +214,7 @@ if exists(.LastAttrChangeDate) {
 if exists(.FileNameCreationDate) {
   fnc_raw = to_string!(del(.FileNameCreationDate))
   if fnc_raw != "" {
-    fnc = parse_timestamp(fnc_raw, "%F %T%.f") ?? parse_timestamp(fnc_raw, "%F %T") ?? null
+    fnc = parse_timestamp(fnc_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnc_raw, "%F %T", "UTC") ?? null
     if fnc != null {
       .file.Ext.ntfs.fn_creation = fnc
     } else {
@@ -226,7 +226,7 @@ if exists(.FileNameCreationDate) {
 if exists(.FileNameLastModificationDate) {
   fnlm_raw = to_string!(del(.FileNameLastModificationDate))
   if fnlm_raw != "" {
-    fnlm = parse_timestamp(fnlm_raw, "%F %T%.f") ?? parse_timestamp(fnlm_raw, "%F %T") ?? null
+    fnlm = parse_timestamp(fnlm_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnlm_raw, "%F %T", "UTC") ?? null
     if fnlm != null {
       .file.Ext.ntfs.fn_last_modification = fnlm
     } else {
@@ -238,7 +238,7 @@ if exists(.FileNameLastModificationDate) {
 if exists(.FileNameLastAccessDate) {
   fnla_raw = to_string!(del(.FileNameLastAccessDate))
   if fnla_raw != "" {
-    fnla = parse_timestamp(fnla_raw, "%F %T%.f") ?? parse_timestamp(fnla_raw, "%F %T") ?? null
+    fnla = parse_timestamp(fnla_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnla_raw, "%F %T", "UTC") ?? null
     if fnla != null {
       .file.Ext.ntfs.fn_last_access = fnla
     } else {
@@ -250,7 +250,7 @@ if exists(.FileNameLastAccessDate) {
 if exists(.FileNameLastAttrModificationDate) {
   fnlac_raw = to_string!(del(.FileNameLastAttrModificationDate))
   if fnlac_raw != "" {
-    fnlac = parse_timestamp(fnlac_raw, "%F %T%.f") ?? parse_timestamp(fnlac_raw, "%F %T") ?? null
+    fnlac = parse_timestamp(fnlac_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnlac_raw, "%F %T", "UTC") ?? null
     if fnlac != null {
       .file.Ext.ntfs.fn_last_attr_change = fnlac
     } else {

--- a/OSIR/configs/dependencies/ecs_normalize/windows/NTFSInfo_i30.vrl
+++ b/OSIR/configs/dependencies/ecs_normalize/windows/NTFSInfo_i30.vrl
@@ -100,7 +100,7 @@ if exists(.FilenameFlags) {
 if exists(.FileNameCreationDate) {
   fnc_raw = to_string!(del(.FileNameCreationDate))
   if fnc_raw != "" {
-    fnc = parse_timestamp(fnc_raw, "%F %T%.f") ?? parse_timestamp(fnc_raw, "%F %T") ?? null
+    fnc = parse_timestamp(fnc_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnc_raw, "%F %T", "UTC") ?? null
     if fnc != null {
       .file.Ext.ntfs.fn_creation = fnc
     } else {
@@ -113,7 +113,7 @@ if exists(.FileNameCreationDate) {
 if exists(.FileNameLastModificationDate) {
   fnlm_raw = to_string!(del(.FileNameLastModificationDate))
   if fnlm_raw != "" {
-    fnlm = parse_timestamp(fnlm_raw, "%F %T%.f") ?? parse_timestamp(fnlm_raw, "%F %T") ?? null
+    fnlm = parse_timestamp(fnlm_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnlm_raw, "%F %T", "UTC") ?? null
     if fnlm != null {
       .file.Ext.ntfs.fn_last_modification = fnlm
     } else {
@@ -126,7 +126,7 @@ if exists(.FileNameLastModificationDate) {
 if exists(.FileNameLastAccessDate) {
   fnla_raw = to_string!(del(.FileNameLastAccessDate))
   if fnla_raw != "" {
-    fnla = parse_timestamp(fnla_raw, "%F %T%.f") ?? parse_timestamp(fnla_raw, "%F %T") ?? null
+    fnla = parse_timestamp(fnla_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnla_raw, "%F %T", "UTC") ?? null
     if fnla != null {
       .file.Ext.ntfs.fn_last_access = fnla
     } else {
@@ -139,7 +139,7 @@ if exists(.FileNameLastAccessDate) {
 if exists(.FileNameLastAttrModificationDate) {
   fnlac_raw = to_string!(del(.FileNameLastAttrModificationDate))
   if fnlac_raw != "" {
-    fnlac = parse_timestamp(fnlac_raw, "%F %T%.f") ?? parse_timestamp(fnlac_raw, "%F %T") ?? null
+    fnlac = parse_timestamp(fnlac_raw, "%F %T%.f", "UTC") ?? parse_timestamp(fnlac_raw, "%F %T", "UTC") ?? null
     if fnlac != null {
       .file.Ext.ntfs.fn_last_attr_change = fnlac
     } else {

--- a/OSIR/configs/dependencies/ecs_normalize/windows/evtx.vrl
+++ b/OSIR/configs/dependencies/ecs_normalize/windows/evtx.vrl
@@ -161,15 +161,15 @@ if !exists(.destination.domain) {
     }
 }
 
-# Source domain: SourceHostname > WorkstationName (non-empty)
-if !exists(.source.domain) {
-    source_domain_candidates = compact([
+# Source hostname: SourceHostname > WorkstationName (non-empty)
+if !exists(.source.hostname) {
+    source_hostname_candidates = compact([
         .Event.EventData.SourceHostname,
         .Event.EventData.WorkstationName
     ])
 
-    if length(source_domain_candidates) > 0 {
-        .source.domain = get!(source_domain_candidates, [0])
+    if length(source_hostname_candidates) > 0 {
+        .source.hostname = get!(source_hostname_candidates, [0])
     }
 }
 

--- a/OSIR/configs/dependencies/ecs_normalize/windows/hives.vrl
+++ b/OSIR/configs/dependencies/ecs_normalize/windows/hives.vrl
@@ -694,7 +694,7 @@ if !exists(.event.sequence) && exists(.CacheEntryPosition) {
 if exists(.Timestamp) && !exists(.event.created) {
   ts_raw = to_string!(del(.Timestamp))
   if ts_raw != "" {
-    ts_val = parse_timestamp(ts_raw, "%F %T%.f") ?? parse_timestamp(ts_raw, "%F %T") ?? null
+    ts_val = parse_timestamp(ts_raw, "%F %T%.f", "UTC") ?? parse_timestamp(ts_raw, "%F %T", "UTC") ?? null
     if ts_val != null {
       .event.created = ts_val
     } else {
@@ -808,7 +808,7 @@ if exists(.event.created) {
 if ts_value == null && exists(.event.timestamp_raw) {
   raw = to_string!(.event.timestamp_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.timestamp_raw"
@@ -819,7 +819,7 @@ if ts_value == null && exists(.event.timestamp_raw) {
 if ts_value == null && exists(.event.created_on_raw) {
   raw = to_string!(.event.created_on_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.created_on_raw"
@@ -830,7 +830,7 @@ if ts_value == null && exists(.event.created_on_raw) {
 if ts_value == null && exists(.event.executed_on_raw) {
   raw = to_string!(.event.executed_on_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.executed_on_raw"
@@ -841,7 +841,7 @@ if ts_value == null && exists(.event.executed_on_raw) {
 if ts_value == null && exists(.event.execution_time_raw) {
   raw = to_string!(.event.execution_time_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.execution_time_raw"
@@ -852,7 +852,7 @@ if ts_value == null && exists(.event.execution_time_raw) {
 if ts_value == null && exists(.event.expires_on_raw) {
   raw = to_string!(.event.expires_on_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.expires_on_raw"
@@ -863,7 +863,7 @@ if ts_value == null && exists(.event.expires_on_raw) {
 if ts_value == null && exists(.event.install_date_raw) {
   raw = to_string!(.event.install_date_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.install_date_raw"
@@ -874,7 +874,7 @@ if ts_value == null && exists(.event.install_date_raw) {
 if ts_value == null && exists(.event.install_time_raw) {
   raw = to_string!(.event.install_time_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.install_time_raw"
@@ -885,7 +885,7 @@ if ts_value == null && exists(.event.install_time_raw) {
 if ts_value == null && exists(.event.initial_timestamp_raw) {
   raw = to_string!(.event.initial_timestamp_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.initial_timestamp_raw"
@@ -896,7 +896,7 @@ if ts_value == null && exists(.event.initial_timestamp_raw) {
 if ts_value == null && exists(.event.installed_raw) {
   raw = to_string!(.event.installed_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.installed_raw"
@@ -907,7 +907,7 @@ if ts_value == null && exists(.event.installed_raw) {
 if ts_value == null && exists(.event.first_installed_raw) {
   raw = to_string!(.event.first_installed_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.first_installed_raw"
@@ -918,7 +918,7 @@ if ts_value == null && exists(.event.first_installed_raw) {
 if ts_value == null && exists(.event.first_connect_local_raw) {
   raw = to_string!(.event.first_connect_local_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.first_connect_local_raw"
@@ -929,7 +929,7 @@ if ts_value == null && exists(.event.first_connect_local_raw) {
 if ts_value == null && exists(.event.last_connected_local_raw) {
   raw = to_string!(.event.last_connected_local_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_connected_local_raw"
@@ -940,7 +940,7 @@ if ts_value == null && exists(.event.last_connected_local_raw) {
 if ts_value == null && exists(.event.last_closed_raw) {
   raw = to_string!(.event.last_closed_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_closed_raw"
@@ -951,7 +951,7 @@ if ts_value == null && exists(.event.last_closed_raw) {
 if ts_value == null && exists(.event.last_connected_raw) {
   raw = to_string!(.event.last_connected_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_connected_raw"
@@ -962,7 +962,7 @@ if ts_value == null && exists(.event.last_connected_raw) {
 if ts_value == null && exists(.event.last_removed_raw) {
   raw = to_string!(.event.last_removed_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_removed_raw"
@@ -973,7 +973,7 @@ if ts_value == null && exists(.event.last_removed_raw) {
 if ts_value == null && exists(.event.last_seen_raw) {
   raw = to_string!(.event.last_seen_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_seen_raw"
@@ -984,7 +984,7 @@ if ts_value == null && exists(.event.last_seen_raw) {
 if ts_value == null && exists(.event.last_start_raw) {
   raw = to_string!(.event.last_start_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_start_raw"
@@ -995,7 +995,7 @@ if ts_value == null && exists(.event.last_start_raw) {
 if ts_value == null && exists(.event.last_stop_raw) {
   raw = to_string!(.event.last_stop_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_stop_raw"
@@ -1006,7 +1006,7 @@ if ts_value == null && exists(.event.last_stop_raw) {
 if ts_value == null && exists(.event.last_write_timestamp_raw) {
   raw = to_string!(.event.last_write_timestamp_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_write_timestamp_raw"
@@ -1017,7 +1017,7 @@ if ts_value == null && exists(.event.last_write_timestamp_raw) {
 if ts_value == null && exists(.event.last_modified_raw) {
   raw = to_string!(.event.last_modified_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_modified_raw"
@@ -1028,7 +1028,7 @@ if ts_value == null && exists(.event.last_modified_raw) {
 if ts_value == null && exists(.event.last_detection_time_raw) {
   raw = to_string!(.event.last_detection_time_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_detection_time_raw"
@@ -1039,7 +1039,7 @@ if ts_value == null && exists(.event.last_detection_time_raw) {
 if ts_value == null && exists(.event.last_executed_raw) {
   raw = to_string!(.event.last_executed_raw)
   if raw != "" {
-    v = parse_timestamp(raw, "%F %T%.f") ?? parse_timestamp(raw, "%F %T") ?? null
+    v = parse_timestamp(raw, "%F %T%.f", "UTC") ?? parse_timestamp(raw, "%F %T", "UTC") ?? null
     if v != null {
       ts_value = v
       ts_source = "event.last_executed_raw"

--- a/OSIR/configs/dependencies/transform/linux/mactime.vrl
+++ b/OSIR/configs/dependencies/transform/linux/mactime.vrl
@@ -1,0 +1,94 @@
+
+
+# -----------------------------------------------------------------------------
+# set_timestamp
+# -----------------------------------------------------------------------------
+if exists(.Date) {
+  .timestamp = to_string!(.Date)
+}
+
+# -----------------------------------------------------------------------------
+# set_file
+# -----------------------------------------------------------------------------
+if exists(.Size) {
+  .file.size = to_int!(.Size)
+}
+if exists(.Mode) {
+  .file.mode = to_string!(.Mode)
+}
+if exists(.UID) {
+  .file.uid = to_int!(.UID)
+}
+if exists(.GID) {
+  .file.gid = to_int!(.GID)
+}
+.file.name = get!(., path: ["File Name"])
+if exists(.Meta) {
+  .file.meta = to_string!(.Meta)
+}
+
+# -----------------------------------------------------------------------------
+# set_message
+# -----------------------------------------------------------------------------
+.event.action = get(value: {
+  "...b": "Created",
+  ".a.b": "Created",
+  ".acb": "Created",
+  ".ab.": "Created",
+  "m..b": "Created",
+  "ma.b": "Created",
+  "macb": "Created",
+  "m.cb": "Created",
+  "..cb": "Created",
+  "..c.": "Created",
+  ".ac.": "Created",
+  "m.c.": "Created",
+  "mac.": "Created",
+  "m...": "Modified",
+  "ma..": "Modified",
+  ".a..": "Accessed",
+  "....": "No activity recorded",
+}, path: [.Type]) ?? "Unknown"
+
+# -----------------------------------------------------------------------------
+# del_raw
+# -----------------------------------------------------------------------------
+del(.Date)
+del(.Size)
+del(.Type)
+del(.Mode)
+del(.UID)
+del(.GID)
+del(.Meta)
+del(."File Name")
+
+# -----------------------------------------------------------------------------
+# descriptions
+# -----------------------------------------------------------------------------
+if exists(.file.name) && exists(.event.action) {
+  .message = to_string!(.file.name) + " — " + to_string!(.event.action)
+}
+if exists(.file.size) && exists(.file.name) && exists(.event.action) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes) — " + to_string!(.event.action)
+}
+if .event.action == "No activity recorded" && exists(.file.name) {
+  .message = to_string!(.file.name) + " — No activity recorded"
+}
+if exists(.file.size) && exists(.file.mode) && .event.action == "Created" && exists(.file.name) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes, mode " + to_string!(.file.mode) + ") — Created"
+}
+if exists(.file.size) && exists(.file.mode) && .event.action == "Modified" && exists(.file.name) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes, mode " + to_string!(.file.mode) + ") — Modified"
+}
+if exists(.file.size) && exists(.file.mode) && .event.action == "Accessed" && exists(.file.name) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes, mode " + to_string!(.file.mode) + ") — Accessed"
+}
+if exists(.file.size) && exists(.file.mode) && exists(.file.uid) && .event.action == "Created" && exists(.file.name) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes, mode " + to_string!(.file.mode) + ") — Created by " + to_string!(.file.uid)
+}
+if exists(.file.size) && exists(.file.mode) && exists(.file.uid) && .event.action == "Modified" && exists(.file.name) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes, mode " + to_string!(.file.mode) + ") — Modified by " + to_string!(.file.uid)
+}
+if exists(.file.size) && exists(.file.mode) && exists(.file.uid) && .event.action == "Accessed" && exists(.file.name) {
+  .message = to_string!(.file.name) + " (" + to_string!(.file.size) + " bytes, mode " + to_string!(.file.mode) + ") — Accessed by " + to_string!(.file.uid)
+}

--- a/OSIR/configs/dependencies/transform/linux/mactime.yml
+++ b/OSIR/configs/dependencies/transform/linux/mactime.yml
@@ -1,0 +1,134 @@
+metadata:
+  version: "1.0"
+  author: Typ
+  description: osir-mactime | Osir Transform description to normalize Mactime log file.
+
+pipeline:
+  - name: set_timestamp
+  - name: set_file
+  - name: set_message
+  - name: del_raw
+
+stages:
+
+  set_timestamp:
+    actions:
+      - set:
+          timestamp: v'to_string!(.Date)'
+
+  set_file:
+    actions:
+      - set:
+          file.size: v'to_int!(.Size)'
+          file.mode: v'to_string!(.Mode)'
+          file.uid: v'to_int!(.UID)'
+          file.gid: v'to_int!(.GID)'
+          file.name: "v'get!(., path: [\"File Name\"])'"
+          file.meta: v'to_string!(.Meta)'
+  
+  set_message:
+    actions:
+      - translate:
+          mapping:
+            event.action: .Type
+          dictionary:
+            "...b": "Created"
+            ".a.b": "Created"
+            ".acb": "Created"
+            ".ab.": "Created"
+            "m..b": "Created"
+            "ma.b": "Created"
+            "macb": "Created"
+            "m.cb": "Created"
+            "..cb": "Created"
+
+            # ── c présent sans b = Created ───────────────────────────────
+            "..c.": "Created"
+            ".ac.": "Created"
+            "m.c.": "Created"
+            "mac.": "Created"
+
+            # ── m présent sans b ni c = Modified ────────────────────────
+            "m...": "Modified"
+            "ma..": "Modified"
+
+            # ── ni m ni b ni c = Accessed ────────────────────────────────
+            ".a..": "Accessed"
+
+            # ── aucune activité ──────────────────────────────────────────
+            "....": "No activity recorded"
+          fallback: "Unknown"
+  del_raw:
+    actions:
+      - delete:
+          - Date
+          - Size
+          - Type
+          - Mode
+          - UID
+          - GID
+          - Meta
+          - "File Name"
+
+descriptions:
+
+  - message: "{file.name} — {event.action}"
+    conditions: []
+
+  - message: "{file.name} ({file.size} bytes) — {event.action}"
+    conditions:
+      - field: file.size
+
+  - message: "{file.name} ({file.size} bytes, mode {file.mode}) — Created"
+    conditions:
+      - field: file.size
+      - field: file.mode
+      - field: event.action
+        value: "Created"
+
+  - message: "{file.name} ({file.size} bytes, mode {file.mode}) — Created by {file.uid}"
+    conditions:
+      - field: file.size
+      - field: file.mode
+      - field: file.uid
+      - field: event.action
+        value: "Created"
+
+  - message: "{file.name} ({file.size} bytes, mode {file.mode}) — Modified"
+    conditions:
+      - field: file.size
+      - field: file.mode
+      - field: event.action
+        value: "Modified"
+
+  - message: "{file.name} ({file.size} bytes, mode {file.mode}) — Modified by {file.uid}"
+    conditions:
+      - field: file.size
+      - field: file.mode
+      - field: file.uid
+      - field: event.action
+        value: "Modified"
+
+  - message: "{file.name} ({file.size} bytes, mode {file.mode}) — Accessed"
+    conditions:
+      - field: file.size
+      - field: file.mode
+      - field: event.action
+        value: "Accessed"
+
+  - message: "{file.name} ({file.size} bytes, mode {file.mode}) — Accessed by {file.uid}"
+    conditions:
+      - field: file.size
+      - field: file.mode
+      - field: file.uid
+      - field: event.action
+        value: "Accessed"
+
+  - message: "{file.name} — No activity recorded"
+    conditions:
+      - field: event.action
+        value: "No activity recorded"
+
+fields:
+  - name: file.meta
+    type: keyword

--- a/OSIR/configs/dependencies/transform/network/zeek_conn.yml
+++ b/OSIR/configs/dependencies/transform/network/zeek_conn.yml
@@ -1,0 +1,202 @@
+metadata:
+  version: "1.0"
+  author: Typ
+  description: Zeek Conn | Osir Transform description to normalize Zeek conn.log file.
+
+pipeline:
+  - name: set_timestamp
+  - name: set_event
+  - name: set_source
+  - name: set_destination
+  - name: set_network
+  - name: del_zeek
+
+stages:
+
+  set_timestamp:
+    actions:
+      - set:
+          "@timestamp": v'parse_timestamp(.ts, "%s") ?? .ts'
+
+  set_event:
+    actions:
+      - set:
+          event.kind:     "event"
+          event.category: ["network"]
+          event.type:     ["connection"]
+          event.dataset:  "zeek.conn"
+          event.module:   "zeek"
+          event.id:       v'to_string!(.uid)'
+          event.duration: v'to_int!(float!(.duration))'
+
+      - translate:
+          mapping:
+            .conn_state: event.action
+          dictionary:
+            S0:     "connection_attempt_no_reply"
+            S1:     "connection_established"
+            SF:     "connection_closed_normally"
+            REJ:    "connection_rejected"
+            S2:     "connection_closed_originator"
+            S3:     "connection_closed_responder"
+            RSTO:   "connection_reset_originator"
+            RSTR:   "connection_reset_responder"
+            RSTOS0: "originator_reset_attempt"
+            RSTRH:  "responder_reset_attempt"
+            SH:     "fin_originator_no_reply"
+            SHR:    "fin_responder_no_reply"
+            OTH:    "no_syn_seen"
+          fallback: "unknown"
+
+  set_source:
+    actions:
+      - set:
+          source.ip:       v'to_string!(.id.orig_h)'
+          source.port:     v'to_int!(.id.orig_p)'
+          source.bytes:    v'to_int!(.orig_bytes)'
+          source.packets:  v'to_int!(.orig_pkts)'
+          source.ip_bytes: v'to_int!(.orig_ip_bytes)'
+
+      - set:
+          source.internal: true
+        filter: v'starts_with!(to_string!(.id.orig_h), "192.168.") || starts_with!(to_string!(.id.orig_h), "10.") || starts_with!(to_string!(.id.orig_h), "172.16.")'
+
+  set_destination:
+    actions:
+      - set:
+          destination.ip:       v'to_string!(.id.resp_h)'
+          destination.port:     v'to_int!(.id.resp_p)'
+          destination.bytes:    v'to_int!(.resp_bytes)'
+          destination.packets:  v'to_int!(.resp_pkts)'
+          destination.ip_bytes: v'to_int!(.resp_ip_bytes)'
+
+  set_network:
+    actions:
+      - set:
+          network.transport: v'downcase!(to_string!(.proto))'
+          network.protocol:  v'downcase!(to_string!(.service))'
+          network.bytes:     v'to_int!(.orig_bytes) + to_int!(.resp_bytes)'
+          network.packets:   v'to_int!(.orig_pkts)  + to_int!(.resp_pkts)'
+          network.history:   v'to_string!(.history)'
+          network.ip_proto:  v'to_int!(.ip_proto)'
+      - custom:
+          event.status: v|
+              if .EventID == 4624 {
+                .event.status = "success"
+              } else if .EventID == 4625 {
+                .event.status = "failure"
+              } else {
+                .event.status = "unknown"
+              }
+
+  del_zeek:
+    actions:
+      - delete:
+          - ts
+          - uid
+          - id.orig_h
+          - id.orig_p
+          - id.resp_h
+          - id.resp_p
+          - proto
+          - ip_proto
+          - service
+          - duration
+          - orig_bytes
+          - resp_bytes
+          - orig_pkts
+          - resp_pkts
+          - orig_ip_bytes
+          - resp_ip_bytes
+          - missed_bytes
+          - conn_state
+          - history
+
+descriptions:
+
+  - message: "Connection {event.action} from {source.ip}:{source.port} to {destination.ip}:{destination.port}"
+    conditions: []
+
+  - message: "Connection {event.action} from {source.ip}:{source.port} to {destination.ip}:{destination.port} via {network.protocol}"
+    conditions:
+      - field: network.protocol
+
+  - message: "{source.ip}:{source.port} -> {destination.ip}:{destination.port} ({network.transport}) {network.bytes} bytes"
+    conditions:
+      - field: network.bytes
+
+  - message: "Internal host {source.ip} -> {destination.ip}:{destination.port} ({network.protocol}) {network.bytes} bytes"
+    relationships:
+      - source: source.ip
+        target: destination.ip
+        type:   connected to
+    conditions:
+      - field: source.internal
+        value: true
+      - field: network.protocol
+      - field: network.bytes
+
+  - message: "Internal host {source.ip} -> {destination.ip}:{destination.port} ({network.transport}) {network.bytes} bytes"
+    relationships:
+      - source: source.ip
+        target: destination.ip
+        type:   connected to
+    conditions:
+      - field: source.internal
+        value: true
+      - field: network.bytes
+
+  - message: "{source.ip}:{source.port} -> {destination.ip}:{destination.port} — connection rejected"
+    relationships:
+      - source: source.ip
+        target: destination.ip
+        type:   attempted to connect to
+    conditions:
+      - field: event.action
+        value: "connection_rejected"
+
+  - message: "{source.ip}:{source.port} -> {destination.ip}:{destination.port} — no reply ({network.transport})"
+    relationships:
+      - source: source.ip
+        target: destination.ip
+        type:   attempted to connect to
+    conditions:
+      - field: event.action
+        value: "connection_attempt_no_reply"
+
+fields:
+  - name: source.bytes
+    description: "Total number of payload bytes sent from the source to the destination, excluding packet headers."
+    type: number
+
+  - name: source.packets
+    description: "Total number of packets sent from the source to the destination."
+    type: number
+
+  - name: source.ip_bytes
+    description: "Total number of IP-level bytes (including headers) sent from the source to the destination."
+    type: number
+
+  - name: destination.bytes
+    description: "Total number of payload bytes sent from the destination to the source, excluding packet headers."
+    type: number
+
+  - name: destination.packets
+    description: "Total number of packets sent from the destination to the source."
+    type: number
+
+  - name: destination.ip_bytes
+    description: "Total number of IP-level bytes (including headers) sent from the destination to the source."
+    type: number
+
+  - name: network.history
+    description: "The state history of the connection as a string of state transitions observed."
+    type: keyword
+
+  - name: network.missed_bytes
+    description: "Number of payload bytes missed in content gaps."
+    type: number
+
+  - name: network.ip_proto
+    description: "The IP protocol number (e.g., 6 for TCP, 17 for UDP)."
+    type: number

--- a/OSIR/configs/modules/connector/indexer_file_csv.yml
+++ b/OSIR/configs/modules/connector/indexer_file_csv.yml
@@ -1,0 +1,31 @@
+metadata:
+  version: "1.0"
+  author: typ
+  description: Splunk logs ingestion (DFIR ORC and UAC) using module-specific json2splunk-rs
+    configuration.
+  os: generic
+
+configuration:
+  module: indexer_ng
+  type: post_parsing
+  disk_only: false
+  no_multithread: false
+  processor_type:
+  - internal
+  processor_os: unix
+
+tool: 
+  path: json2splunk-rs
+  cmd: >-
+    --input {input_dir_replaced_by_internal_module} --index {case_name} --config_spl /OSIR/setup/conf/agent.yml 
+    --indexer_patterns {indexer_path} --vrl_dir /OSIR/OSIR/configs/dependencies/
+  source: https://github.com/maxspl/json2splunk-rs/releases
+  version: 1.4
+
+input:
+  type: file
+  path: "{case_path}"
+
+output:
+  type: single_file
+  format: jsonl

--- a/OSIR/configs/modules/network/zeek_log.yml
+++ b/OSIR/configs/modules/network/zeek_log.yml
@@ -1,11 +1,11 @@
 metadata:
   version: "2.0"
   author: Typ
-  description: Parsing logs from '/var/log/audit'
+  description: Parsing logs from Zeek
   os: unix
 
 configuration:
-  module: audit
+  module: zeek_log
   type: process
   disk_only: true
   no_multithread: true
@@ -15,13 +15,13 @@ configuration:
 
 input:
   type: file
-  name: (?:auth\.log)
-  path: var/log/
+  paths:
+    - r"conn\.log$"
 
 output:
   type: single_file
   format: json
-  output_file: "{endpoint_name}--{module}-{input_file}.jsonl"
+  output_file: "{endpoint_name}--{input_file}.jsonl"
 
 endpoint: 
   patterns:
@@ -29,9 +29,9 @@ endpoint:
   default: "UNKNOWN"
 
 splunk:
-  'linux:audit':
+  'linux:network:zeek':
     name_rex: \.jsonl$
-    sourcetype: 'linux:audit'
+    sourcetype: 'linux:network:zeek'
     host_rex: "\/Endpoint_(.*?)\/"
     timestamp_path: 
         - "_time"

--- a/OSIR/configs/modules/pre_process/dfir_orc_decrypt.yml
+++ b/OSIR/configs/modules/pre_process/dfir_orc_decrypt.yml
@@ -17,7 +17,7 @@ tool:
   path: orc-decrypt-rs
   source: 
   version: 
-  cmd: -k /OSIR/OSIR/configs/dependencies/encryption/DFIRORC_key.pem --output-dir {output_dir}/{endpoint_name} {input_file}
+  cmd: -k /OSIR/OSIR/configs/dependencies/encryption/DFIRORC_key.pem --output-dir {output_dir}/{endpoint_name} -f {input_file}
 
 input:
   type: file

--- a/OSIR/configs/modules/pre_process/extract_orc.yml
+++ b/OSIR/configs/modules/pre_process/extract_orc.yml
@@ -21,7 +21,8 @@ tool:
   cmd: x -o{m_output_dir} -y {m_input_file} -p"{optional_password}"
 input:
   type: file
-  name: ^DFIR-ORC_(?:Server|WorkStation|DomainController)_((?:\w|-|\.)+)_(\w+)\.7z$
+  paths:
+    - r"DFIR-ORC(?:-\w+)?_(?:Server|WorkStation|DomainController)_([\w.\-]+?)(?:_\w+)*\.(?:7z|json|log)$"
 output:
   type: multiple_files
   format: raw

--- a/OSIR/configs/modules/pre_process/orc_offline.yml
+++ b/OSIR/configs/modules/pre_process/orc_offline.yml
@@ -1,5 +1,5 @@
 metadata:
-  version: "2.0"
+  version: "3.0"
   author: maxspl
   description: Used to execute DFIR ORC on dd capture
   os: windows
@@ -8,7 +8,7 @@ configuration:
   module: orc_offline
   type: pre-process
   disk_only: false
-  no_multithread: true
+  no_multithread: false
   processor_type:
   - external
   processor_os: windows

--- a/OSIR/configs/modules/pre_process/orc_offline.yml
+++ b/OSIR/configs/modules/pre_process/orc_offline.yml
@@ -1,5 +1,5 @@
 metadata:
-  version: "3.0"
+  version: "2.0"
   author: maxspl
   description: Used to execute DFIR ORC on dd capture
   os: windows
@@ -8,7 +8,7 @@ configuration:
   module: orc_offline
   type: pre-process
   disk_only: false
-  no_multithread: false
+  no_multithread: true
   processor_type:
   - external
   processor_os: windows

--- a/OSIR/configs/modules/splunk/indexer_ng.yml
+++ b/OSIR/configs/modules/splunk/indexer_ng.yml
@@ -20,7 +20,7 @@ tool:
     --input {input_dir_replaced_by_internal_module} --index {case_name} --config_spl /OSIR/setup/conf/agent.yml 
     --indexer_patterns {indexer_path} --vrl_dir /OSIR/OSIR/configs/dependencies/
   source: https://github.com/maxspl/json2splunk-rs/releases
-  version: 1.4
+  version: 1.6
 
 input:
   type: dir

--- a/OSIR/configs/modules/unix/mactime.yml
+++ b/OSIR/configs/modules/unix/mactime.yml
@@ -40,8 +40,8 @@ splunk:
     sourcetype: 'linux:files:bodyfile'
     host_rex: ([\w\.-]+)--
     timestamp_path: 
-        - "mtime"
+        - "timestamp"
     timestamp_format: "%Y-%m-%dT%H:%M:%SZ"
     artifact: "bodyfile"
     normalize:
-      - ecs_normalize/linux/mactime.vrl
+      - transform/linux/mactime.vrl

--- a/OSIR/configs/modules/windows/collect_info_orc.yml
+++ b/OSIR/configs/modules/windows/collect_info_orc.yml
@@ -15,13 +15,13 @@ configuration:
 
 tool: 
   path: /usr/bin/find
-  cmd:  -P {input_dir} -name "DFIR-ORC_*.7z" -exec sh -c
-    'sha1=$(sha1sum "$1" | awk "{print \$1}");
-    birth=$(stat -c %W "$1");
-    [ "$birth" = "-1" ] && birth=$(stat -c %Y "$1");
-    jq -n -c --arg sha1 "$sha1" --arg date "$birth" --arg name "$(basename "$1")" "{sha1:\$sha1,date:\$date,name:\$name}"' sh {} \;
-    > {output_file}
-
+  cmd: >-
+    -P {input_dir} -name "DFIR-ORC_*.7z" -exec sh -c 'sha1=$(sha1sum "$1" | awk
+    "{print \$1}"); birth=$(stat -c %W "$1"); [ "$birth" = "-1" ] && birth=$(stat
+    -c %Y "$1"); size=$(stat -c %s "$1"); jq -n -c --arg sha1 "$sha1" --arg date
+    "$birth" --arg name "$(basename "$1")" --arg size "$size"
+    "{sha1:\$sha1,date:\$date,name:\$name,size:(\$size|tonumber)}"' sh {} \; >
+    {output_file}
 input:
   type: dir
   path: extract_orc/*

--- a/OSIR/configs/modules/windows/evtx.yml
+++ b/OSIR/configs/modules/windows/evtx.yml
@@ -15,7 +15,7 @@ configuration:
 
 tool: 
   path: evtx_dump
-  cmd: -f {output_file} -o jsonl {input_file} --no-confirm-overwrite
+  cmd: -f "{output_file}" -o jsonl "{input_file}" --no-confirm-overwrite
   source: https://github.com/omerbenamram/evtx/releases
   version: 0.11.2
 

--- a/OSIR/configs/modules/windows/orc_outcome.yml
+++ b/OSIR/configs/modules/windows/orc_outcome.yml
@@ -1,0 +1,36 @@
+metadata:
+  version: "1.0"
+  author: maxspl
+  description: Process DFIR ORC outcome and outline json files.
+  os: windows
+
+configuration:
+  module: orc_outcome
+  type: process
+  disk_only: true
+  no_multithread: false
+  processor_type:
+  - external
+  processor_os: unix
+
+tool: 
+  path: python
+  cmd: /OSIR/OSIR/bin/orc_outcome.py --input-dir {input_dir} --output-dir {output_dir}
+  source:
+  version: 2026.04.12
+
+
+input:
+  type: dir
+  paths:
+    - extract_orc/*
+
+output:
+  type: multiple_files
+  format: raw
+
+splunk:
+  'windows:orc_outcome':
+    name_rex: \.jsonl$
+    path_suffix: orc_outcome
+    host_rex: orc_outcome_([^_]+)_\d{8}_\d{6}\.jsonl$

--- a/OSIR/src/osir_lib/osir_lib/core/OsirTool.py
+++ b/OSIR/src/osir_lib/osir_lib/core/OsirTool.py
@@ -186,7 +186,7 @@ class OsirTool(OsirToolModel, OsirPathTransformerMixin):
             logger.error(f"Unidentified error: Error : {str(e)}")
             raise
 
-    def run_local(self, is_agent=False, timeout=3600) -> bool:
+    def run_local(self, is_agent=False, timeout=36000) -> bool:
         """
             Spawns a local subprocess to run the tool directly on the current host.
 

--- a/OSIR/src/osir_lib/osir_lib/core/OsirUtils.py
+++ b/OSIR/src/osir_lib/osir_lib/core/OsirUtils.py
@@ -136,3 +136,27 @@ def compute_file_xxh3_128_prefix(path, prefix_size: int = 8192) -> str:
     with p.open("rb") as f:
         h.update(f.read(prefix_size))
     return h.hexdigest()
+
+
+def compute_file_xxh3_128_full(path, chunk_size: int = 1024 * 1024) -> str:
+    """
+    Computes xxh3_128 on the whole file.
+
+    Args:
+        path (str | Path): Path to the file.
+        chunk_size (int): Read size per chunk.
+
+    Returns:
+        str: Hex digest of xxh3_128 over the full file.
+    """
+    p = _Path(path)
+    h = xxhash.xxh3_128()
+
+    with p.open("rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+
+    return h.hexdigest()

--- a/OSIR/src/osir_lib/osir_lib/core/model/OsirMetadataModel.py
+++ b/OSIR/src/osir_lib/osir_lib/core/model/OsirMetadataModel.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel
 from osir_lib.core.model.LiteralModel import OS_TYPE
 from osir_lib.logger import AppLogger
@@ -12,5 +13,5 @@ class OsirMetadataModel(BaseModel):
     version: str
     author: str
     description: str
-    os: OS_TYPE
+    os: Optional[OS_TYPE] = None
     

--- a/OSIR/src/osir_lib/osir_lib/modules/network/zeek_log.py
+++ b/OSIR/src/osir_lib/osir_lib/modules/network/zeek_log.py
@@ -1,0 +1,45 @@
+from osir_lib.core.OsirDecorator import osir_internal_module
+from osir_lib.core.LogUtils import LogUtils
+from osir_lib.core.OsirModule import OsirModule, Path
+from osir_lib.logger import AppLogger, CustomLogger
+
+logger: CustomLogger = AppLogger().get_logger()
+
+@osir_internal_module
+class ZeekConnModule(LogUtils):
+    """
+    PyModule to perform processing operations on Zeek conn.log.
+    """
+
+    def __init__(self, module: OsirModule):
+        """
+        Initializes the Module.
+
+        Args:
+            case_path (str): The directory path where case files are stored and operations are performed.
+            module (OsirModule): Instance of OsirModule containing configuration details for the extraction process.
+        """
+        self.module = module
+        self._file_to_process = module.input.match
+
+    def __call__(self) -> bool:
+        """
+        Execute the internal processor of the module.
+
+        Returns:
+            bool: True if the processing completes successfully, False otherwise.
+        """
+        try:
+            logger.debug(f"Processing file {self._file_to_process}")
+
+            from zat.log_to_dataframe import LogToDataFrame
+
+            input_path  = Path(self.module.input.match)
+            df = LogToDataFrame().create_dataframe(str(input_path))
+            df.to_json(self.module.output.output_file, orient="records", lines=True)
+
+            logger.debug(f"{self.module.module_name} done")
+            return True
+        except Exception as exc:
+            logger.error_handler(exc)
+            return False

--- a/OSIR/src/osir_lib/osir_lib/modules/windows/extract_orc.py
+++ b/OSIR/src/osir_lib/osir_lib/modules/windows/extract_orc.py
@@ -27,7 +27,13 @@ class ORC_Extractor():
         self._cmd = self.module.tool.cmd  # Save cmd with place holders for further interations
         self._case_path = case_path  # Base directory for operations
         self._file_to_process = module.input.match
-        self._name_rex = self.module.input.name
+        self._name_rex = getattr(module.input, 'name', None)
+        if not self._name_rex and hasattr(module.input, 'paths'):
+            for p in module.input.paths:
+                clean = p[2:-1] if p.startswith(('r"', "r'")) else p
+                if '(' in clean:  # has capture groups
+                    self._name_rex = clean
+                    break
 
     def __call__(self) -> bool:
         """
@@ -63,16 +69,23 @@ class ORC_Extractor():
         Moves the specified archive to a new location and extracts its contents, preserving the original directory structure.
         This method handles file matching, directory creation, and manages extraction for both top-level and nested archives.
         """
-        pattern = re.compile(self._name_rex)
-
-        match = pattern.match(os.path.basename(self._file_to_process))
-        endpoint_name, archive_name = match.groups()
-        archive_path = self._file_to_process
+        match = re.search(self._name_rex, str(self._file_to_process))
+        file_path = str(self._file_to_process)
+        basename = os.path.basename(file_path)
+        endpoint_name = match.group(1).lower()
         archive_path = self._file_to_process
         endpoint_dir = os.path.join(self._case_path, self.module.get_module_name(), "Endpoint_" + endpoint_name)
         os.makedirs(endpoint_dir, exist_ok=True)
+
+        # move json outcome/outline and log files
+        if basename.endswith(('.json', '.log')):
+            shutil.move(file_path, os.path.join(endpoint_dir, basename))
+            logger.debug(f"Moved {basename} to {endpoint_dir}")
+            return
+
         moved_archive_path = os.path.join(endpoint_dir, os.path.basename(self._file_to_process))
         shutil.move(archive_path, moved_archive_path)
+        archive_name = os.path.splitext(basename)[0].rsplit('_', 1)[-1]
         extraction_dir = os.path.join(endpoint_dir, "extracted_files", archive_name)
         os.makedirs(extraction_dir, exist_ok=True)
         try:

--- a/OSIR/src/osir_service/osir_service/watchdog/WatchdogService.py
+++ b/OSIR/src/osir_service/osir_service/watchdog/WatchdogService.py
@@ -18,500 +18,872 @@ from osir_service.orchestration.TaskService import TaskService
 from osir_service.postgres.OsirDb import OsirDb
 from osir_lib.logger import AppLogger
 
+from collections import defaultdict
+
 logger = AppLogger(__name__).get_logger()
 
 
+class _CompiledRule:
+    """Pre-compiled module rule for O(1) hot-path dispatch."""
+    __slots__ = (
+        'module', 'module_name', 'input_type',
+        'output_dir', 'alt_output_dir',
+        'output_dir_str', 'alt_output_dir_str',
+        'patterns',
+        'ext_anchors', 'basename_anchors',
+    )
+
+    def __init__(
+        self,
+        module,
+        module_name,
+        input_type,
+        output_dir,
+        alt_output_dir,
+        output_dir_str,
+        alt_output_dir_str,
+        patterns,
+        ext_anchors,
+        basename_anchors,
+    ):
+        self.module = module
+        self.module_name = module_name
+        self.input_type = input_type
+
+        self.output_dir = output_dir
+        self.alt_output_dir = alt_output_dir
+
+        self.output_dir_str = output_dir_str
+        self.alt_output_dir_str = alt_output_dir_str
+
+        self.patterns = patterns
+        self.ext_anchors = ext_anchors
+        self.basename_anchors = basename_anchors
+
+
+class _LegacyRule:
+    """Pre-compiled legacy module rule."""
+    __slots__ = (
+        'module_instance', 'module_name', 'input_type', 'module_path',
+        'file_regex', 'path_pattern_suffix', 'wildcard_pattern',
+        'is_path_regex', 'path_regex',
+    )
+
+    def __init__(
+        self,
+        module_instance,
+        module_name,
+        input_type,
+        module_path,
+        file_regex,
+        path_pattern_suffix,
+        wildcard_pattern,
+        is_path_regex,
+        path_regex,
+    ):
+        self.module_instance = module_instance
+        self.module_name = module_name
+        self.input_type = input_type
+        self.module_path = module_path
+        self.file_regex = file_regex
+        self.path_pattern_suffix = path_pattern_suffix
+        self.wildcard_pattern = wildcard_pattern
+        self.is_path_regex = is_path_regex
+        self.path_regex = path_regex
+
+
 class CaseSnapshot:
-    """
-    Class to snapshot the directory entries.
-    """
+    """Iterative directory snapshot used for change detection between scan cycles."""
 
     def __init__(self, case_path):
-        """
-        Initialize the CaseSnapshot with the given case path.
-
-        Args:
-            case_path (str): The path of the case to snapshot.
-        """
         self.case_path = case_path
-        self.entries = []
+        self.entries: set = set()
 
     def scan_directory(self):
-        """
-        Scan the directory and subdirectories to record entries.
-        """
-        self.entries = []  # Reset entries before scanning
+        """Scan the full directory tree iteratively and store as a set."""
+        entries: set = set()
+        entries.add((self.case_path, 'directory'))
+        stack = [self.case_path]
 
-        def scan(current_path):
-            with os.scandir(current_path) as it:
-                for entry in it:
-                    try:
-                        if entry.is_dir():
-                            self.entries.append((entry.path, 'directory'))
-                            scan(entry.path)  # Recursively scan subdirectory
-                        elif entry.is_file():
-                            self.entries.append((entry.path, 'file'))
-                    except OSError as e:
-                        logger.warning(f"Unreadable entries : {entry}. Error: {str(e)}")
-                        continue
-                    
-        scan(self.case_path)
-        # Add case_path
-        self.entries.append((self.case_path, 'directory'))
+        while stack:
+            current = stack.pop()
+            try:
+                with os.scandir(current) as it:
+                    for entry in it:
+                        try:
+                            if entry.is_dir():
+                                entries.add((entry.path, 'directory'))
+                                stack.append(entry.path)
+                            elif entry.is_file():
+                                entries.add((entry.path, 'file'))
+                        except OSError as e:
+                            logger.warning(f"Unreadable entry: {entry}. Error: {e}")
+            except OSError as e:
+                logger.warning(f"Cannot scan directory: {current}. Error: {e}")
 
-    def get_entries_set(self):
-        """
-        Get a set of the directory entries for easy comparison.
+        self.entries = entries
 
-        Returns:
-            set: A set of tuples representing the entries.
-        """
-        # Return a set of entries for easy comparison
-        return set(self.entries)
+    def get_entries_set(self) -> set:
+        return self.entries
 
 
 class ModuleHandler(FileSystemEventHandler):
     """
-    Handles file system events to trigger processing modules based on file or directory changes that match specified patterns.
+    Handles file system events to trigger processing modules based on file or directory changes.
     """
 
-    def __init__(self, case_path: Path, cooldown_period: int, module_instances: list[OsirModuleModel], case_uuid, handler_uuid=None):
-        """
-        Initializes the ModuleHandler with configurations to monitor file and directory events related to a specific case.
-
-        Args:
-            case_path (str): Base path on master's disk of the case to monitor.
-            modules_info (list): List of module information dicts.
-            cooldown_period (int): Cooldown period between checks in seconds.
-            module_instances (list): List of module instances to execute.
-            case_uuid (str): Unique identifier for the case.
-        """
+    def __init__(
+        self,
+        case_path: Path,
+        cooldown_period: int,
+        module_instances: list[OsirModuleModel],
+        case_uuid,
+        handler_uuid=None,
+    ):
         self.handler_uuid = handler_uuid if handler_uuid else uuid.uuid4()
         self.cooldown = cooldown_period
         self.watch_directory = case_path
         self.case_path = case_path
+        self._case_path_str = os.path.abspath(str(case_path))
+
         self.last_modified_times = {}
         self.module_instances: list[OsirModuleModel] = module_instances
         self.case_uuid = case_uuid
 
-        self.last_size = {}
-        self.last_processed = set()
+        self.last_mtime: dict[str, float] = {}
+        self.last_processed: set = set()
 
         self.agent_config = OsirAgentConfig()
 
-        # Used to check if file already processed under another name
-        self._seen_prefix_lock = threading.Lock()
-        self._seen_prefix = set()
+        self._task_counter_lock = threading.Lock()
+        self._tasks_pushed_by_module = defaultdict(int)
 
-        # Initialize a set and a lock to keep track of active timers
-        self.active_timers = set()
+        self._seen_prefix_lock = threading.Lock()
+
+        # Dedup cache:
+        # key:
+        #   (module_name, file_size, hash_mode, file_hash)
+        # value:
+        #   first file path seen with this same key
+        self._seen_prefix: dict[tuple, str] = {}
+
+        self.active_timers: set = set()
         self.timers_lock = threading.Lock()
+
+        self._virtual_dir = (Path(case_path) / 'virtual').resolve()
+        self._virtual_dir_str = os.path.abspath(str(Path(case_path) / 'virtual'))
+
+        self._dir_rules: list[_CompiledRule] = []
+        self._file_rules_by_ext: dict[str, list[_CompiledRule]] = {}
+        self._file_rules_by_basename: dict[str, list[_CompiledRule]] = {}
+        self._file_rules_unindexed: list[_CompiledRule] = []
+        self._legacy_file_rules: list[_LegacyRule] = []
+        self._legacy_dir_rules: list[_LegacyRule] = []
+
+        self._compile_rules(case_path, module_instances)
+
+        # For some modules, duplicate detection requires full-file hash.
+        self._full_hash_dedup_modules = {
+            "evtx",
+        }
+
         with OsirDb() as db:
             db.handler.create(
                 handler_id=self.handler_uuid,
                 case_uuid=self.case_uuid,
                 modules=[module.module_name for module in module_instances],
-                task_ids=[]
+                task_ids=[],
             )
+
+    # ------------------------------------------------------------------
+    # Rule compilation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_glob_anchors(pattern: str) -> set[str]:
+        """Extract a literal extension or basename anchor from a glob pattern."""
+        last_seg = pattern.rstrip('/').split('/')[-1].lower()
+
+        if not last_seg:
+            return set()
+
+        if not any(c in last_seg for c in ['*', '?', '[']):
+            _, ext = os.path.splitext(last_seg)
+            return {ext} if ext else {last_seg}
+
+        if last_seg.startswith('*.') and last_seg.count('*') == 1 and '?' not in last_seg:
+            return {last_seg[1:]}
+
+        return set()
+
+    @staticmethod
+    def _glob_to_compiled_re(pattern: str) -> re.Pattern:
+        """Convert a glob pattern (Path.match semantics) to a compiled regex.
+
+        Relative patterns match from the right; absolute patterns match from the left.
+        '*' matches any characters except '/'; '**' matches zero or more path components.
+        """
+        pat = pattern.replace('\\', '/')
+        is_absolute = pat.startswith('/')
+        parts = pat.lstrip('/').split('/')
+
+        seg_regexes = []
+        for part in parts:
+            if part == '**':
+                seg_regexes.append('**')
+            else:
+                seg = re.escape(part).replace(r'\*', '[^/]*').replace(r'\?', '[^/]')
+                seg_regexes.append(seg)
+
+        pieces = []
+        for i, seg in enumerate(seg_regexes):
+            if i == 0:
+                pieces.append('(?:[^/]+/)*' if seg == '**' else seg)
+            else:
+                prev = seg_regexes[i - 1]
+                if seg == '**':
+                    pieces.append('/(?:[^/]+/)*')
+                elif prev == '**':
+                    pieces.append(seg)
+                else:
+                    pieces.append('/' + seg)
+
+        body = ''.join(pieces)
+        if is_absolute:
+            return re.compile('^/' + body + '$')
+        return re.compile('(?:^|/)' + body + '$')
+
+    @staticmethod
+    def _extract_regex_anchors(pattern: str) -> set[str]:
+        """Extract literal extension anchors from a regex pattern."""
+        m = re.search(r'\\\.([a-zA-Z0-9]+)\b', pattern)
+        if m:
+            return {'.' + m.group(1).lower()}
+
+        m = re.search(r'\\\.\(([a-zA-Z0-9|]+)\)', pattern)
+        if m:
+            return {'.' + ext.lower() for ext in m.group(1).split('|')}
+
+        return set()
+
+    @staticmethod
+    def _is_under_or_equal(path: str, root: str | None) -> bool:
+        """
+        Fast path containment check.
+
+        Returns True when `path` is equal to `root` or located under `root`.
+        """
+        if not root:
+            return False
+
+        try:
+            return os.path.commonpath([path, root]) == root
+        except ValueError:
+            return False
+
+    def _consume_tasks_pushed_by_module(self) -> dict[str, int]:
+        """
+        Return task counters since the previous scan iteration, then reset them.
+        """
+        with self._task_counter_lock:
+            counters = dict(self._tasks_pushed_by_module)
+            self._tasks_pushed_by_module.clear()
+            return counters
+
+    def _compile_rules(self, case_path: Path, module_instances: list[OsirModuleModel]):
+        """
+        Pre-compile all module rules once at startup.
+        """
+        case_path_str = str(case_path)
+
+        for module in module_instances:
+            if not (hasattr(module.input, 'paths') and module.input.paths):
+                path_pattern = module.input.path.rstrip('/') if module.input.path else None
+                is_path_regex = (
+                    path_pattern.startswith('r"') and path_pattern.endswith('"')
+                    if path_pattern else False
+                )
+
+                legacy = _LegacyRule(
+                    module_instance=module,
+                    module_name=module.module_name,
+                    input_type=module.input.type,
+                    module_path=os.path.join(case_path_str, module.module_name),
+                    file_regex=re.compile(module.input.name) if module.input.name else None,
+                    path_pattern_suffix=path_pattern,
+                    wildcard_pattern=path_pattern.rstrip('/*') if path_pattern else None,
+                    is_path_regex=is_path_regex,
+                    path_regex=re.compile(path_pattern[2:-1]) if is_path_regex else None,
+                )
+
+                if module.input.type == "dir":
+                    self._legacy_dir_rules.append(legacy)
+                else:
+                    self._legacy_file_rules.append(legacy)
+
+                continue
+
+            output_dir = (Path(case_path) / module.module_name).resolve()
+            output_dir_str = os.path.abspath(str(output_dir))
+
+            alt_output_dir = None
+            alt_output_dir_str = None
+
+            if module.output.output_dir and '{case_path}' in module.output.output_dir:
+                try:
+                    alt_output_dir = Path(
+                        remove_placeholders(
+                            module.output.output_dir.replace('{case_path}', case_path_str)
+                        )
+                    ).resolve()
+                    alt_output_dir_str = os.path.abspath(str(alt_output_dir))
+                except Exception:
+                    pass
+
+            patterns: list[re.Pattern] = []
+            ext_anchors: set[str] = set()
+            basename_anchors: set[str] = set()
+            all_anchored = True
+
+            for pat in module.input.paths:
+                pat = pat.replace("{case_path}", case_path_str)
+
+                if pat.startswith(('r"', "r'")):
+                    raw = pat[2:-1]
+                    anchors = self._extract_regex_anchors(raw)
+                    compiled = re.compile(raw)
+                elif any(c in pat for c in ['^', '$', '(', '|']):
+                    anchors = self._extract_regex_anchors(pat)
+                    compiled = re.compile(pat)
+                else:
+                    anchors = self._extract_glob_anchors(pat)
+                    compiled = self._glob_to_compiled_re(pat)
+
+                patterns.append(compiled)
+
+                if all_anchored:
+                    if not anchors:
+                        all_anchored = False
+                    else:
+                        for anchor in anchors:
+                            if anchor.startswith('.'):
+                                ext_anchors.add(anchor)
+                            else:
+                                basename_anchors.add(anchor)
+
+            rule = _CompiledRule(
+                module=module,
+                module_name=module.module_name,
+                input_type=module.input.type,
+                output_dir=output_dir,
+                alt_output_dir=alt_output_dir,
+                output_dir_str=output_dir_str,
+                alt_output_dir_str=alt_output_dir_str,
+                patterns=patterns,
+                ext_anchors=frozenset(ext_anchors),
+                basename_anchors=frozenset(basename_anchors),
+            )
+
+            if module.input.type == "dir":
+                self._dir_rules.append(rule)
+            else:
+                if all_anchored and (ext_anchors or basename_anchors):
+                    for ext in ext_anchors:
+                        self._file_rules_by_ext.setdefault(ext, []).append(rule)
+
+                    for basename in basename_anchors:
+                        self._file_rules_by_basename.setdefault(basename, []).append(rule)
+                else:
+                    self._file_rules_unindexed.append(rule)
+
+        indexed = (
+            sum(len(v) for v in self._file_rules_by_ext.values()) +
+            sum(len(v) for v in self._file_rules_by_basename.values())
+        )
+
+        logger.debug(
+            f"Rules compiled: {len(self._dir_rules)} dir | "
+            f"{indexed} indexed file | "
+            f"{len(self._file_rules_unindexed)} unindexed file | "
+            f"{len(self._legacy_dir_rules) + len(self._legacy_file_rules)} legacy"
+        )
+
+    # ------------------------------------------------------------------
+    # Directory monitoring loop
+    # ------------------------------------------------------------------
 
     def monitor_directory(self, case_path, interval=5, reprocess=False):
         """
         Monitors the directory for changes at specified intervals.
-
-        Args:
-            case_path (str): Path of the case to monitor.
-            interval (int, optional): Interval in seconds to wait between scans. Default is 5 seconds.
-            reprocess (bool): If True, it will reprocess all the files. If False, files that were present during previous execution will not be processed.
         """
         casesnapshot = CaseSnapshot(case_path)
 
         if not reprocess:
-            # Fetch previously stored entries
             logger.debug(f"Fetching previously stored entries for case_uuid={self.case_uuid}")
             with OsirDb() as db:
                 previous_entries = set(db.snapshot.get_stored_case_snapshot(case_path))
+
             if not previous_entries:
                 logger.debug("No previous entries found, starting with an empty set.")
         else:
             previous_entries = set()
 
+        scan_iterations = 0
+
         while True:
+            scan_iterations += 1
+            iteration_start_time = time.time()
             logger.debug("Scanning for new files/folders")
+
             scan_case_start_time = time.time()
             casesnapshot.scan_directory()
             current_entries = casesnapshot.get_entries_set()
-            scan_case_end_time = time.time()
-            scan_case_duration = scan_case_end_time - scan_case_start_time
+            scan_case_duration = time.time() - scan_case_start_time
+
             logger.debug(f"Time taken to scan case: {scan_case_duration:.4} seconds.")
+
             new_entries = current_entries - previous_entries
+            n_new_entries = len(new_entries)
+            new_entries_duration = 0.0
+
             if new_entries:
                 new_entries_start_time = time.time()
-                logger.debug(f"New files/folders detected : {len(new_entries)} new items")
+                logger.debug(f"New files/folders detected : {n_new_entries} new items")
+
                 for entry in new_entries:
                     item_path, entry_type = entry
+
                     if entry_type == 'file':
                         self.on_created(FileCreatedEvent(item_path))
                     elif entry_type == 'directory':
                         self.on_created(DirCreatedEvent(item_path))
 
-                new_entries_end_time = time.time()
-                new_entries_duration = new_entries_end_time - new_entries_start_time
+                new_entries_duration = time.time() - new_entries_start_time
                 logger.debug(f"Time taken to process new items: {new_entries_duration:.4} seconds")
             else:
                 logger.debug("No new item detected. Checking if a task is still ongoing before exiting...")
+
                 with OsirDb() as db:
                     if not db.handler.is_processing_active(self.handler_uuid):
                         with self.timers_lock:
                             if not self.active_timers:
-                                logger.debug("Case snaphost is being saved before exiting...")
-                                db.snapshot.store_case_snapshot(self.case_uuid, case_path, list(current_entries))
+                                logger.debug("Case snapshot is being saved before exiting...")
+                                db.snapshot.store_case_snapshot(
+                                    self.case_uuid,
+                                    case_path,
+                                    list(current_entries),
+                                )
+
                                 if db.handler.check_handler_failure(self.handler_uuid):
                                     db.handler.update(self.handler_uuid, "processing_failed")
                                 else:
                                     db.handler.update(self.handler_uuid, "processing_done")
+
                                 exit()
+
+            iteration_duration = time.time() - iteration_start_time
+
+            tasks_pushed_by_module = self._consume_tasks_pushed_by_module()
+
+            if tasks_pushed_by_module:
+                tasks_summary = ", ".join(
+                    f"{module_name}={count}"
+                    for module_name, count in sorted(tasks_pushed_by_module.items())
+                )
+            else:
+                tasks_summary = "none"
+
+            logger.info(
+                f"Scan iteration {scan_iterations}: {iteration_duration:.2f}s total "
+                f"(dir scan: {scan_case_duration:.2f}s, entry processing: {new_entries_duration:.2f}s, "
+                f"{n_new_entries} new entries, tasks pushed: {tasks_summary})"
+            )
+
             previous_entries = current_entries
 
             time.sleep(interval)
 
-    def check_match(self, src_path, pattern, module_name):
-        src_path_obj = Path(src_path)
-        src_path_str = str(src_path_obj)
+    # ------------------------------------------------------------------
+    # Event dispatch
+    # ------------------------------------------------------------------
 
-        is_regex = False
-        clean_pattern = pattern
+    def _dispatch_rule(self, event, src_abs: str, rule: _CompiledRule):
+        """Match one pre-compiled rule against an event and trigger processing if it matches."""
 
-        if pattern.startswith(('r"', "r'")):
-            is_regex = True
-            clean_pattern = pattern[2:-1]
-        elif any(c in pattern for c in ['^', '$', '(', '|']):
-            is_regex = True
-
-        if is_regex:
-            if re.search(clean_pattern, src_path_str):
-                logger.info(f"MATCH [Regex] : {src_path_str} avec {pattern} (Module: {module_name})")
-                return True
-        else:
-            if src_path_obj.match(pattern):
-                logger.info(f"MATCH [Glob] : {src_path_str} avec {pattern} (Module: {module_name})")
-                return True
-
-        return False
-
-    def on_created_new(self, event, module: OsirModuleModel):
-        """
-        Handles the creation of new files or directories by checking them against 
-        module-specific filtering rules before triggering processing.
-
-        Args:
-            event (watchdog.events.FileSystemEvent): The event object representing 
-                the file system change.
-            module (OsirModuleModel): The module configuration containing input 
-                types, patterns, and processing logic.
-
-        Returns:
-            None: This method performs actions (logging, triggering processing) 
-                but does not return a value.
-        """
-        if not hasattr(event, 'src_path'):
-            logger.warning("Event without path, ignored.")
+        if self._is_under_or_equal(src_abs, rule.output_dir_str):
             return
 
-        src_path = Path(event.src_path)
-
-        if event.is_directory and module.input.type != "dir":
+        if self._is_under_or_equal(src_abs, rule.alt_output_dir_str):
             return
 
-        if not event.is_directory and module.input.type != "file":
+        if self._is_under_or_equal(src_abs, self._virtual_dir_str) and f"{os.sep}fs{os.sep}" not in src_abs:
             return
 
-        output_dir = Path(self.case_path) / module.module_name
-        event_path = Path(event.src_path).resolve()
-
-        if output_dir in event_path.parents or event_path == output_dir:
-            return
-        
-        if module.output.output_dir and '{case_path}' in module.output.output_dir:
-            alt_output_dir = Path(remove_placeholders(module.output.output_dir.replace('{case_path}', str(self.case_path))))
-            if alt_output_dir in event_path.parents or event_path == alt_output_dir:
-                return
-
-        # Only process FS folder in mounted disk
-        virtual_dir = Path(self.case_path) / 'virtual'
-        if virtual_dir in event_path.parents:
-            if '/fs/' not in str(event_path):
-                return
-
-        file_module_pair = (event.src_path, module.module_name)
+        file_module_pair = (event.src_path, rule.module_name)
 
         if file_module_pair in self.last_processed:
             return
 
-        if not hasattr(module.input, 'paths') or not module.input.paths:
-            logger.debug(f"No path pattern defined for the module {module.__class__.__name__}, skipping.")
+        for pat in rule.patterns:
+            if not pat.search(src_abs):
+                continue
+
+            logger.info(
+                f"MATCH: {src_abs} avec {pat.pattern} (Module: {rule.module_name})"
+            )
+
+            self.last_processed.add(file_module_pair)
+
+            if rule.input_type == "dir":
+                self.handle_directory_event(event, rule.module)
+            else:
+                try:
+                    (
+                        is_duplicate,
+                        duplicate_of,
+                        hash_mode,
+                        file_hash,
+                        file_size,
+                    ) = self._check_duplicate_by_hash(
+                        module_name=rule.module_name,
+                        file_path=event.src_path,
+                        prefix_size=81920,
+                    )
+
+                    if is_duplicate:
+                        logger.info(
+                            f"{rule.module_name} - Skipping duplicate file: "
+                            f"skipped_file='{event.src_path}' | "
+                            f"same_hash_as='{duplicate_of}' | "
+                            f"hash_mode='{hash_mode}' | "
+                            f"size={file_size} | "
+                            f"xxh3_128='{file_hash}'"
+                        )
+                        return
+
+                except Exception as e:
+                    logger.warning(
+                        f"{rule.module_name} - Hash dedup failed for {event.src_path}: {e}"
+                    )
+
+                self.process(event.src_path, rule.module)
+
+            break
+
+    def on_created(self, event):
+        """Dispatch a file/directory creation event to all matching module rules."""
+        if not hasattr(event, 'src_path'):
+            logger.warning("Event without path, ignored.")
             return
 
-        for pattern in module.input.paths:
+        src_abs = os.path.abspath(event.src_path)
 
-            if "{case_path}" in pattern:
-                pattern = pattern.replace("{case_path}", str(self.case_path))
+        if event.is_directory:
+            for rule in self._dir_rules:
+                self._dispatch_rule(event, src_abs, rule)
 
-            if self.check_match(src_path, pattern, module.__class__.__name__):
+            for rule in self._legacy_dir_rules:
+                self._on_created_legacy(event, rule)
+
+        else:
+            src_lower = event.src_path.lower()
+            ext = os.path.splitext(src_lower)[1]
+            basename = os.path.basename(src_lower)
+
+            seen: set[int] = set()
+
+            for rule in self._file_rules_by_ext.get(ext, ()):
+                seen.add(id(rule))
+                self._dispatch_rule(event, src_abs, rule)
+
+            for rule in self._file_rules_by_basename.get(basename, ()):
+                if id(rule) not in seen:
+                    seen.add(id(rule))
+                    self._dispatch_rule(event, src_abs, rule)
+
+            for rule in self._file_rules_unindexed:
+                self._dispatch_rule(event, src_abs, rule)
+
+            for rule in self._legacy_file_rules:
+                self._on_created_legacy(event, rule)
+
+    def _on_created_legacy(self, event, rule: _LegacyRule):
+        """Legacy dispatch path for modules using input.path/input.name."""
+        file_module_pair = (event.src_path, rule.module_name)
+        module_path = rule.module_path
+        input_type = rule.input_type
+        path_pattern_suffix = rule.path_pattern_suffix
+        wildcard_pattern = rule.wildcard_pattern
+        file_regex = rule.file_regex
+        is_path_regex = rule.is_path_regex
+        path_regex = rule.path_regex
+
+        if (
+            str(module_path) not in str(event.src_path)
+            and input_type == "dir"
+            and event.is_directory
+        ):
+            if is_path_regex and path_regex.search(str(event.src_path)):
+                logger.debug(
+                    f"{rule.module_name} Directory '{event.src_path}' will be processed "
+                    f"(regex match)"
+                )
+                self.handle_directory_event(event, rule.module_instance)
+
+            elif (
+                path_pattern_suffix == "{case_path}"
+                and str(event.src_path) == str(self.case_path)
+            ):
+                logger.debug(f"{rule.module_name} Directory '{event.src_path}' will be processed")
+                self.handle_directory_event(event, rule.module_instance)
+
+            elif (
+                path_pattern_suffix
+                and "{case_path}" in path_pattern_suffix
+                and event.src_path == path_pattern_suffix.replace("{case_path}", str(self.case_path))
+            ):
+                logger.debug(f"{rule.module_name} Directory '{event.src_path}' will be processed")
+                self.handle_directory_event(event, rule.module_instance)
+
+            elif (
+                path_pattern_suffix
+                and path_pattern_suffix.endswith('/*')
+                and os.path.dirname(event.src_path).lower().endswith(wildcard_pattern.lower())
+            ):
+                logger.debug(f"{rule.module_name} Directory '{event.src_path}' will be processed")
+                self.handle_directory_event(event, rule.module_instance)
+
+            elif path_pattern_suffix and str(event.src_path).lower().endswith(
+                path_pattern_suffix.lower()
+            ):
+                logger.debug(f"{rule.module_name} Directory '{event.src_path}' will be processed")
+                self.handle_directory_event(event, rule.module_instance)
+
+        elif (
+            str(module_path) not in str(os.path.dirname(event.src_path))
+            and input_type == "file"
+            and not event.is_directory
+            and file_module_pair not in self.last_processed
+        ):
+            if is_path_regex and path_regex.search(event.src_path):
+                if file_regex is not None and re.search(file_regex, os.path.basename(event.src_path)):
+                    self.last_processed.add(file_module_pair)
+                    self.process(event.src_path, rule.module_instance)
+
+            elif path_pattern_suffix and file_regex is not None and not file_regex.pattern:
+                if event.src_path.lower().endswith(path_pattern_suffix.lower()):
+                    self.last_processed.add(file_module_pair)
+                    self.process(event.src_path, rule.module_instance)
+
+            elif (
+                path_pattern_suffix
+                and '/*' in path_pattern_suffix
+                and path_pattern_suffix.replace('/*', '') in event.src_path.lower()
+                and file_regex is not None
+                and re.search(file_regex, os.path.basename(event.src_path))
+            ):
                 self.last_processed.add(file_module_pair)
-                # logger.warning(self.last_processed)
-                if module.input.type == "dir":
-                    self.handle_directory_event(event, module)
-                elif module.input.type == "file":
-                    # Content-based dedup (prefix hash + size) to avoid duplicates under different paths.
-                    try:
-                        if self._is_duplicate_by_prefix_hash(
-                            module_name=module.module_name,
-                            file_path=event.src_path,
-                            prefix_size=81920
-                        ):
-                            logger.info(f"{module.module_name} - Skipping duplicate (prefix xxh3_128): {event.src_path}")
-                            return
-                    except Exception as e:
-                        logger.warning(f"{module.module_name} - Prefix hash dedup failed for {event.src_path}: {e}")
-                    self.process(event.src_path, module)
+                self.process(event.src_path, rule.module_instance)
 
-                break
+            elif path_pattern_suffix and file_regex is not None and file_regex.pattern:
+                if (
+                    os.path.dirname(event.src_path).lower().endswith(path_pattern_suffix.lower())
+                    and re.search(file_regex, os.path.basename(event.src_path))
+                ):
+                    self.last_processed.add(file_module_pair)
+                    self.process(event.src_path, rule.module_instance)
 
-    def on_created(self, event):  # triggered for files and dir but targets dirs only
-        """
-        Specific handler for 'created' events, which are triggered when a new file or directory is created.
+            elif not path_pattern_suffix and file_regex is not None and file_regex.pattern:
+                if re.search(file_regex, os.path.basename(event.src_path)):
+                    self.last_processed.add(file_module_pair)
+                    self.process(event.src_path, rule.module_instance)
 
-        Args:
-            event: The event object representing the file or directory creation event.
-        """
-        for module_instance in self.module_instances:
-            # TODO: Test this with a full profile
-            if hasattr(module_instance.input, 'paths') and module_instance.input.paths:
-                self.on_created_new(event, module_instance)
-            # TODO: Remove this LEGACY
-            else:
-                if module_instance.input.path:
-                    path_pattern = module_instance.input.path.rstrip('/')
-                else:
-                    path_pattern = None  # No path criteria given
-
-                module_info = {
-                    "module_name": module_instance.module_name,
-                    "file_regex": module_instance.input.name,
-                    "path_pattern_suffix": path_pattern,
-                    "input_type": module_instance.input.type
-                }
-                if module_info["file_regex"]:
-                    file_regex = re.compile(module_info["file_regex"])
-                path_pattern_suffix = module_info["path_pattern_suffix"]
-                if path_pattern_suffix:
-                    wildcard_pattern = path_pattern_suffix.rstrip('/*')  # Wildcard can be used after suffix to match any directory (not recursive)
-                module_name = module_info["module_name"]
-                input_type = module_info["input_type"]
-                module_path = os.path.join(self.case_path, module_name)
-                # Create a tuple of (file_path, module_name)
-                file_module_pair = (event.src_path, module_name)
-
-                # Check if path_pattern_suffix is a regex
-                is_path_pattern_suffix_regex = path_pattern_suffix.startswith("r\"") and path_pattern_suffix.endswith("\"") if path_pattern_suffix else None
-                if is_path_pattern_suffix_regex:
-                    # Strip r"" and compile the regex
-                    path_regex = re.compile(path_pattern_suffix[2:-1])
-                else:
-                    wildcard_pattern = path_pattern_suffix.rstrip('/*') if path_pattern_suffix else None  # Wildcard can be used after suffix to match any directory (not recursive)
-
-                # Handle dirs
-                if (str(module_path) not in str(event.src_path) and  # don't process input if it is in the same module directory
-                        input_type == "dir" and
-                        event.is_directory):
-
-                    if is_path_pattern_suffix_regex and path_regex.search(str(event.src_path)):  # Regex match for directories
-                        logger.debug(f"{module_name} Directory '{event.src_path}' will be processed (regex match)")
-                        self.handle_directory_event(event, module_instance)
-                    # Handle case where input dir is case directory
-                    elif (path_pattern_suffix == "{case_path}" and
-                            str(event.src_path) == str(self.case_path)):
-                        logger.debug(f"{module_name} Directory '{event.src_path}' will be processed")
-                        self.handle_directory_event(event, module_instance)
-                    elif ("{case_path}" in path_pattern_suffix and event.src_path == path_pattern_suffix.replace("{case_path}", str(self.case_path))):
-                        logger.debug(f"{module_name} Directory '{event.src_path}' will be processed")
-                        self.handle_directory_event(event, module_instance)
-                    elif path_pattern_suffix.endswith('/*') and os.path.dirname(event.src_path).lower().endswith(wildcard_pattern.lower()):
-                        logger.debug(f"{module_name} Directory '{event.src_path}' will be processed")
-                        self.handle_directory_event(event, module_instance)
-                    elif str(event.src_path).lower().endswith(path_pattern_suffix.lower()):
-                        logger.debug(f"{module_name} Directory '{event.src_path}' will be processed")
-                        self.handle_directory_event(event, module_instance)
-
-                # Handle files
-                elif (str(module_path) not in str(os.path.dirname(event.src_path)) and  # don't process input if it is in the same module directory
-                        input_type == "file" and
-                        not event.is_directory and
-                        file_module_pair not in self.last_processed):
-
-                    if is_path_pattern_suffix_regex and path_regex.search(event.src_path):  # Regex match for files
-                        if re.search(file_regex, os.path.basename(event.src_path)):
-                            self.last_processed.add(file_module_pair)
-                            self.process(event.src_path, module_instance)
-                    elif path_pattern_suffix and not file_regex.pattern:  # If only path specified, the event file must end with the path in config
-                        if event.src_path.lower().endswith(path_pattern_suffix.lower()):
-                            self.last_processed.add(file_module_pair)
-                            self.process(event.src_path, module_instance)
-                    # NEED A REVIEW OF THIS ADD !!!!!!!!
-                    elif path_pattern_suffix and '/*' in path_pattern_suffix and path_pattern_suffix.replace('/*', '') in event.src_path.lower() and re.search(file_regex, os.path.basename(event.src_path)):
-                        self.last_processed.add(file_module_pair)
-                        self.process(event.src_path, module_instance)
-
-                    elif path_pattern_suffix and file_regex.pattern:  # If path/file name both specified, the directory of the event file must end with the path in config
-                        if os.path.dirname(event.src_path).lower().endswith(path_pattern_suffix.lower()) and re.search(file_regex, os.path.basename(event.src_path)):
-                            self.last_processed.add(file_module_pair)
-                            self.process(event.src_path, module_instance)
-                    elif not path_pattern_suffix and file_regex.pattern:  # If on_close triggered, the filename regex already matched
-                        if re.search(file_regex, os.path.basename(event.src_path)):
-                            self.last_processed.add(file_module_pair)
-                            self.process(event.src_path, module_instance)
+    # ------------------------------------------------------------------
+    # Directory idle detection
+    # ------------------------------------------------------------------
 
     def handle_directory_event(self, event, module_instance: OsirModuleModel):
         """
         Processes directory events that match configured patterns and sets up checks for idleness.
-
-        Args:
-            event: The event object representing the directory event.
-            module_instance (OsirModuleModel): Module configuration instance
         """
-        current_time = time.time()
-        self.last_modified_times[event.src_path] = current_time
+        self.last_modified_times[event.src_path] = time.time()
+        self.last_mtime[event.src_path] = self._get_directory_mtime(event.src_path)
 
-        # Check directory size immediately and store it
-        current_size = self._get_directory_size(event.src_path)
-        self.last_size[event.src_path] = current_size
-
-        # Start a new timer to check for idleness
         timer = Timer(self.cooldown, self._check_for_idle, [event.src_path, module_instance])
+
         try:
-            logger.debug(f"{module_instance.module_name} Starting timer for IDLE check of '{event.src_path}'")
+            logger.debug(
+                f"{module_instance.module_name} Starting timer for IDLE check of "
+                f"'{event.src_path}'"
+            )
+
             with self.timers_lock:
                 self.active_timers.add(event.src_path)
+
             timer.start()
-            logger.debug(f"{module_instance.module_name} Timer started for IDLE check of '{event.src_path}'")
+
+            logger.debug(
+                f"{module_instance.module_name} Timer started for IDLE check of "
+                f"'{event.src_path}'"
+            )
+
         except Exception as e:
             logger.debug(f"{module_instance.module_name} Timer error for {event.src_path}. {str(e)}")
+
         logger.debug(f"{module_instance.module_name} Directory '{event.src_path}' is busy")
 
-    def _get_directory_size(self, path: str) -> int:
-        root = Path(path)
-        total = 0
-
-        for f in root.rglob('*'):
-            try:
-                if f.is_file():
-                    total += f.stat().st_size
-            except OSError:
-                # Just skip unreadable entries
-                continue
-
-        return total
+    def _get_directory_mtime(self, path: str) -> float:
+        """Return directory mtime."""
+        try:
+            return os.stat(path).st_mtime
+        except OSError:
+            return 0.0
 
     def _check_parent(self, path, module_instance: OsirModuleModel):
         logger.debug(f"Checking if {module_instance.module_name} idle is not parent of another idle")
-        # Convert path to a Path object
+
         path = Path(path).resolve()
+
         for current_idle_path in list(self.active_timers):
             current_idle_path_resolved = Path(current_idle_path).resolve()
-            # Check if the current path is a parent of the active timer path
+
             if current_idle_path_resolved.is_relative_to(path) and path != current_idle_path_resolved:
-                logger.debug(f"{module_instance.module_name} is parent of {current_idle_path}, the module can't be executed")
+                logger.debug(
+                    f"{module_instance.module_name} is parent of {current_idle_path}, "
+                    f"the module can't be executed"
+                )
                 return False
+
         return True
 
     def _check_for_idle(self, path, module_instance: OsirModuleModel):
         """
-        Checks if the directory has been idle based on size changes and triggers further processing if idle.
-
-        Args:
-            path (str): Path to the directory being monitored.
-            module_instance (OsirModuleModel): Module configuration instance
+        Checks if the directory has been idle and triggers processing if idle.
         """
         logger.debug(f"Starting _check_for_idle for {path} - {module_instance.module_name}")
-        current_size = self._get_directory_size(path)
-        previous_size = self.last_size.get(path, 0)
 
-        if current_size == previous_size and self._check_parent(path, module_instance):
+        current_mtime = self._get_directory_mtime(path)
+        previous_mtime = self.last_mtime.get(path, 0.0)
+
+        if current_mtime == previous_mtime and self._check_parent(path, module_instance):
             logger.debug(f"{module_instance.module_name} Directory '{path}' is now idle")
             self.process(path, module_instance)
+
             with self.timers_lock:
                 if path in self.active_timers:
                     self.active_timers.remove(path)
+
         else:
-            logger.debug(f"{module_instance.module_name} Directory '{path}' is still busy, rescheduling check")
-            # Reschedule the check if the directory size has changed
-            self.last_size[path] = current_size
+            logger.debug(
+                f"{module_instance.module_name} Directory '{path}' is still busy, "
+                f"rescheduling check"
+            )
+            self.last_mtime[path] = current_mtime
+
             timer = Timer(self.cooldown, self._check_for_idle, [path, module_instance])
             timer.start()
 
+    # ------------------------------------------------------------------
+    # Task dispatch
+    # ------------------------------------------------------------------
+
     def process(self, file_match: Path, module_instance: OsirModuleModel):
         """
-            Initiates processing of a file or directory based on the module configuration.
-
-            Args:
-                match_path (Path): Path to the file or directory that matched the module input rules.
-                module_instance (OsirModuleModel): Module configuration instance to execute (will be deep-copied and updated).
+        Initiates processing of a file or directory based on the module configuration.
         """
-
-        logger.debug(f"""{module_instance.module_name}.yaml - Processing : \n
+        logger.debug(
+            f"""{module_instance.module_name}.yaml - Processing : \n
                     Case Path : {self.case_path} \n
-                    File Match : {Path(file_match).relative_to(self.case_path)} \n""")
+                    File Match : {Path(file_match).relative_to(self.case_path)} \n"""
+        )
 
         module_instance = copy.deepcopy(module_instance)
-
         module_instance.input.match = str(file_match)
+
         self._push_task(module_instance)
 
     def _push_task(self, module_instance: OsirModuleModel):
         """
-            Pushes a task to the task queue for processing based on the current module configuration.
-
-            Args:
-                module_instance: The module instance to be processed.
+        Pushes a task to the task queue.
         """
-        task_params = (normalize_osir_path(self.case_path), module_instance, self.case_uuid, self.handler_uuid)
+        task_params = (
+            normalize_osir_path(self.case_path),
+            module_instance,
+            self.case_uuid,
+            self.handler_uuid,
+        )
+
         TaskService.push_task(*task_params)
 
-    def _is_duplicate_by_prefix_hash(self, module_name: str, file_path: str, prefix_size: int = 8192) -> bool:
+        with self._task_counter_lock:
+            self._tasks_pushed_by_module[module_instance.module_name] += 1
+
+    # ------------------------------------------------------------------
+    # Dedup helpers
+    # ------------------------------------------------------------------
+
+    def _check_duplicate_by_hash(
+        self,
+        module_name: str,
+        file_path: str,
+        prefix_size: int = 8192,
+    ) -> tuple[bool, str | None, str, str, int]:
         """
-        Checks whether a file should be considered a duplicate using only a prefix hash.
+        Checks whether a file should be considered a duplicate.
 
-        This uses xxh3_128 over the first `prefix_size` bytes (default: 8KB) and stores
-        the resulting signature in an in-memory cache. This prevents re-processing the
-        same content when it appears under different paths/names *during the lifetime
-        of this WatchdogService instance*.
+        Default behavior:
+            Uses xxh3_128 over the first `prefix_size` bytes.
 
-        NOTE:
-            - This is not persisted (duplicates can reappear after restart).
-            - Prefix-hash dedup can cause false duplicates if two different files share
-            the same first bytes.
+        Exception behavior:
+            For modules listed in self._full_hash_dedup_modules, hashes the whole file.
 
-        Args:
-            module_name (str): The module name (dedup scope is per module).
-            file_path (str): Path to the file to hash.
-            prefix_size (int): Prefix size in bytes to hash (default 8192).
+        Dedup scope:
+            Per module, file size, hash mode, and hash value.
 
         Returns:
-            bool: True if the file is considered a duplicate (already seen),
-                False if it is new (and has been recorded).
+            (
+                is_duplicate,
+                duplicate_of,
+                hash_mode,
+                file_hash,
+                file_size,
+            )
+
+        Example:
+            If file B has the same dedup key as file A:
+
+            (
+                True,
+                "/path/to/file_A.evtx",
+                "full",
+                "abc123...",
+                123456
+            )
         """
-        from osir_lib.core.OsirUtils import compute_file_xxh3_128_prefix
+        from osir_lib.core.OsirUtils import (
+            compute_file_xxh3_128_prefix,
+            compute_file_xxh3_128_full,
+        )
 
         try:
             file_size = os.path.getsize(file_path)
         except Exception:
             file_size = -1
 
-        prefix_hash = compute_file_xxh3_128_prefix(file_path, prefix_size=prefix_size)
-        key = (module_name, file_size, prefix_hash)
+        if module_name in self._full_hash_dedup_modules:
+            hash_mode = "full"
+            file_hash = compute_file_xxh3_128_full(file_path)
+        else:
+            hash_mode = f"prefix:{prefix_size}"
+            file_hash = compute_file_xxh3_128_prefix(file_path, prefix_size=prefix_size)
+
+        key = (module_name, file_size, hash_mode, file_hash)
 
         with self._seen_prefix_lock:
-            if key in self._seen_prefix:
-                return True
-            self._seen_prefix.add(key)
-            return False
+            duplicate_of = self._seen_prefix.get(key)
+
+            if duplicate_of is not None:
+                return True, duplicate_of, hash_mode, file_hash, file_size
+
+            self._seen_prefix[key] = file_path
+            return False, None, hash_mode, file_hash, file_size

--- a/OSIR/src/osir_transform/main.py
+++ b/OSIR/src/osir_transform/main.py
@@ -1,0 +1,6 @@
+from osir_transform.OsirTransform import OsirTransform
+
+test = OsirTransform.from_yaml("/home/typ/Desktop/OSIR/OSIR/configs/dependencies/transform/linux/mactime.yml")
+
+test.save_vrl("/home/typ/Desktop/OSIR/OSIR/configs/dependencies/transform/linux/mactime.vrl")
+

--- a/OSIR/src/osir_transform/osir_transform/Description.py
+++ b/OSIR/src/osir_transform/osir_transform/Description.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+import re
+from typing import Any, Optional
+from pydantic import BaseModel
+
+
+class Condition(BaseModel):
+    field: str
+    value: Optional[Any] = None
+
+
+class Relationship(BaseModel):
+    source: str
+    target: str
+    type:   str
+
+
+class Description(BaseModel):
+    message:       str
+    conditions:    list[Condition]    = []
+    relationships: list[Relationship] = []
+
+    def to_vrl(self) -> str:
+        guards   = self._build_guards()
+        template = self._build_template()
+        body: list[str] = [f".message = {template}"]
+        for rel in self.relationships:
+            body.append('if !is_array(.relationships) { .relationships = [] }')
+            body.append(
+                f'.relationships = push!(.relationships, {{'
+                f'"source": to_string!(.{rel.source}), '
+                f'"target": to_string!(.{rel.target}), '
+                f'"type": "{rel.type}"}})'
+            )
+        if guards:
+            inner = "\n  ".join(body)
+            return f"if {guards} {{\n  {inner}\n}}"
+        return "\n".join(body)
+
+    def _template_fields(self) -> list[str]:
+        return re.findall(r'\{([^}]+)\}', self.message)
+
+    def _build_guards(self) -> str:
+        parts = []
+        condition_fields = {c.field for c in self.conditions}
+        for c in self.conditions:
+            field = f".{c.field}"
+            if c.value is None:
+                parts.append(f"exists({field})")
+            elif isinstance(c.value, bool):
+                parts.append(f"{field} == {'true' if c.value else 'false'}")
+            elif isinstance(c.value, str):
+                parts.append(f'{field} == "{c.value}"')
+            else:
+                parts.append(f"{field} == {c.value}")
+        for f in self._template_fields():
+            if f not in condition_fields:
+                parts.append(f"exists(.{f})")
+        return " && ".join(parts)
+
+    def _build_template(self) -> str:
+        parts   = []
+        last    = 0
+        pattern = re.compile(r'\{([^}]+)\}')
+        for match in pattern.finditer(self.message):
+            if match.start() > last:
+                parts.append(f'"{self.message[last:match.start()]}"')
+            parts.append(f"to_string!(.{match.group(1)})")
+            last = match.end()
+        if last < len(self.message):
+            parts.append(f'"{self.message[last:]}"')
+        return " + ".join(parts)

--- a/OSIR/src/osir_transform/osir_transform/Field.py
+++ b/OSIR/src/osir_transform/osir_transform/Field.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class Field(BaseModel):
+    name:        str
+    description: str = ""
+    type:        str

--- a/OSIR/src/osir_transform/osir_transform/OsirTransform.py
+++ b/OSIR/src/osir_transform/osir_transform/OsirTransform.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from .PipelineStep  import PipelineStep, Stage
+from .Description   import Description
+from .Field         import Field
+from .actions       import SetAction, DeleteAction
+from .VRL           import VRL, extract_vrl_fields
+from osir_lib.core.model.OsirMetadataModel import OsirMetadataModel
+
+_HR = "# " + "-" * 77
+
+
+class OsirTransform(BaseModel):
+    metadata:     OsirMetadataModel
+    pipeline:     list[PipelineStep]
+    stages:       dict[str, Stage]
+    fields:       list[Field]       = []
+    descriptions: list[Description] = []
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "OsirTransform":
+        import yaml
+        with open(path, encoding="utf-8") as f:
+            return cls.model_validate(yaml.safe_load(f))
+
+    def to_vrl(self) -> str:
+        return "\n".join([
+            self._pipeline_to_vrl(),
+            self._descriptions_to_vrl(),
+        ])
+
+    def save_vrl(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self.to_vrl())
+
+    # ── dotted field normalization ─────────────────────────────────────────────
+
+    def _collect_dotted_source_fields(self) -> list[str]:
+        seen: dict[str, bool] = {}
+        for step in self.pipeline:
+            if step.name not in self.stages:
+                continue
+            for action in self.stages[step.name].parsed_actions():
+                if not isinstance(action, SetAction):
+                    continue
+                exprs = list(action.set.values())
+                if action.filter:
+                    exprs.append(action.filter)
+                for val in exprs:
+                    if not isinstance(val, VRL):
+                        continue
+                    for ref in extract_vrl_fields(str(val)):
+                        name = ref.lstrip(".")
+                        if "." in name:
+                            seen[name] = True
+        return list(seen.keys())
+
+    def _normalize_dotted_fields_vrl(self) -> str:
+        fields = self._collect_dotted_source_fields()
+        if not fields:
+            return ""
+        lines = [f"\n{_HR}\n# normalize dotted fields\n{_HR}"]
+        for field in fields:
+            lines.append(f'if exists(."{field}") {{ .{field} = get!(., path: ["{field}"]) }}')
+        return "\n".join(lines)
+
+    # ── VRL rendering ──────────────────────────────────────────────────────────
+
+    def _pipeline_to_vrl(self) -> str:
+        flat_fields = set(self._collect_dotted_source_fields())
+        lines: list[str] = [self._normalize_dotted_fields_vrl()]
+        for step in self.pipeline:
+            if step.name not in self.stages:
+                continue
+            lines.append(f"\n{_HR}\n# {step.name}\n{_HR}")
+            for action in self.stages[step.name].parsed_actions():
+                if isinstance(action, DeleteAction):
+                    lines.extend(action.to_vrl(flat_fields))
+                else:
+                    lines.extend(action.to_vrl())
+        return "\n".join(lines)
+
+    def _descriptions_to_vrl(self) -> str:
+        if not self.descriptions:
+            return ""
+        sorted_d = sorted(self.descriptions, key=lambda d: len(d.conditions))
+        lines = [f"\n{_HR}\n# descriptions\n{_HR}"]
+        for d in sorted_d:
+            lines.append(d.to_vrl())
+        return "\n".join(lines)

--- a/OSIR/src/osir_transform/osir_transform/PipelineStep.py
+++ b/OSIR/src/osir_transform/osir_transform/PipelineStep.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from typing import Any, Optional
+from pydantic import BaseModel
+from .VRL import parse_vrl_tag
+from .actions import SetAction, TranslateAction, DeleteAction, CustomAction, Action
+
+
+class PipelineStep(BaseModel):
+    name:   str
+    filter: Optional[str] = None
+
+
+class Stage(BaseModel):
+    actions: list[dict[str, Any]]
+    model_config = {"arbitrary_types_allowed": True}
+
+    def parsed_actions(self) -> list[Action]:
+        result = []
+        for raw in self.actions:
+            raw = parse_vrl_tag(raw)
+            if "set" in raw:
+                result.append(SetAction(set=raw["set"], filter=raw.get("filter")))
+            elif "translate" in raw:
+                t = raw["translate"]
+                result.append(TranslateAction(
+                    mapping=t.get("mapping", {}),
+                    dictionary=t.get("dictionary", {}),
+                    fallback=t.get("fallback"),
+                ))
+            elif "delete" in raw:
+                result.append(DeleteAction(delete=raw["delete"]))
+            elif "custom" in raw:
+                result.append(CustomAction(custom=raw["custom"]))
+        return result

--- a/OSIR/src/osir_transform/osir_transform/VRL.py
+++ b/OSIR/src/osir_transform/osir_transform/VRL.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import re
+from typing import Any
+
+
+class VRL(str):
+    pass
+
+
+def parse_vrl_tag(value: Any) -> Any:
+    if isinstance(value, str):
+        if value.startswith('v"') and value.endswith('"'):
+            return VRL(value[2:-1])
+        if value.startswith("v'") and value.endswith("'"):
+            return VRL(value[2:-1])
+        if value.startswith("v|") or value.startswith("v>"):
+            return VRL(value[2:].strip())
+    if isinstance(value, dict):
+        return {k: parse_vrl_tag(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [parse_vrl_tag(i) for i in value]
+    return value
+
+
+def extract_vrl_fields(expr: str) -> list[str]:
+    """Return deduplicated .field references from a VRL expression, ignoring string literals."""
+    cleaned = re.sub(r'"[^"]*"', '""', expr)
+    fields  = re.findall(r'(\.[a-zA-Z_@][a-zA-Z0-9_.]*)', cleaned)
+    return list(dict.fromkeys(fields))
+
+
+def render_value(val: Any) -> str:
+    if isinstance(val, VRL):  return str(val)
+    if isinstance(val, bool): return "true" if val else "false"
+    if isinstance(val, str):  return f'"{val}"'
+    if isinstance(val, list): return "[" + ", ".join(f'"{i}"' for i in val) + "]"
+    return str(val)

--- a/OSIR/src/osir_transform/osir_transform/__init__.py
+++ b/OSIR/src/osir_transform/osir_transform/__init__.py
@@ -1,0 +1,15 @@
+from .OsirTransform import OsirTransform
+from .actions       import SetAction, TranslateAction, DeleteAction, CustomAction, Action
+from .PipelineStep  import PipelineStep, Stage
+from .Description   import Description, Condition, Relationship
+from .Field         import Field
+from .VRL           import VRL, parse_vrl_tag, extract_vrl_fields, render_value
+
+__all__ = [
+    "OsirTransform",
+    "SetAction", "TranslateAction", "DeleteAction", "CustomAction", "Action",
+    "PipelineStep", "Stage",
+    "Description", "Condition", "Relationship",
+    "Field",
+    "VRL", "parse_vrl_tag", "extract_vrl_fields", "render_value",
+]

--- a/OSIR/src/osir_transform/osir_transform/actions/CustomAction.py
+++ b/OSIR/src/osir_transform/osir_transform/actions/CustomAction.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import Any
+from pydantic import BaseModel
+
+
+class CustomAction(BaseModel):
+    custom: dict[str, Any]
+    model_config = {"arbitrary_types_allowed": True}
+
+    def to_vrl(self) -> list[str]:
+        lines = []
+        for vrl_code in self.custom.values():
+            lines.append(str(vrl_code))
+        return lines

--- a/OSIR/src/osir_transform/osir_transform/actions/DeleteAction.py
+++ b/OSIR/src/osir_transform/osir_transform/actions/DeleteAction.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from pydantic import BaseModel
+
+
+class DeleteAction(BaseModel):
+    delete: list[str]
+
+    def to_vrl(self, flat_fields: set[str] = frozenset()) -> list[str]:
+        lines = []
+        for f in self.delete:
+            if " " in f:
+                lines.append(f'del(."{f}")')
+            elif "." in f and f in flat_fields:
+                lines.append(f'del(."{f}")')
+            else:
+                lines.append(f"del(.{f})")
+        return lines

--- a/OSIR/src/osir_transform/osir_transform/actions/SetAction.py
+++ b/OSIR/src/osir_transform/osir_transform/actions/SetAction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from typing import Any, Optional
+from pydantic import BaseModel
+from ..VRL import VRL, extract_vrl_fields, render_value
+
+
+class SetAction(BaseModel):
+    set:    dict[str, Any]
+    filter: Optional[VRL] = None
+    model_config = {"arbitrary_types_allowed": True}
+
+    def to_vrl(self) -> list[str]:
+        if self.filter:
+            lines = [f"if {self.filter} {{"]
+            for dst, val in self.set.items():
+                lines.extend(self._stmt_lines(dst, val, indent="  "))
+            lines.append("}")
+            return lines
+
+        lines = []
+        for dst, val in self.set.items():
+            lines.extend(self._stmt_lines(dst, val))
+        return lines
+
+    def _stmt_lines(self, dst: str, val: Any, indent: str = "") -> list[str]:
+        stmt = f"{indent}.{dst} = {render_value(val)}"
+        if not isinstance(val, VRL):
+            return [stmt]
+        fields = extract_vrl_fields(str(val))
+        if not fields:
+            return [stmt]
+        guard = " && ".join(f"exists({f})" for f in fields)
+        return [
+            f"{indent}if {guard} {{",
+            f"{indent}  .{dst} = {render_value(val)}",
+            f"{indent}}}",
+        ]

--- a/OSIR/src/osir_transform/osir_transform/actions/TranslateAction.py
+++ b/OSIR/src/osir_transform/osir_transform/actions/TranslateAction.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from typing import Optional
+from pydantic import BaseModel
+
+
+class TranslateAction(BaseModel):
+    mapping:    dict[str, str]
+    dictionary: dict[str, str]
+    fallback:   Optional[str] = None
+
+    def to_vrl(self) -> list[str]:
+        lines = []
+        for dst_field, src_field in self.mapping.items():
+            src          = src_field if src_field.startswith(".") else f".{src_field}"
+            dict_literal = "{\n" + "".join(
+                f'  "{k}": "{v}",\n' for k, v in self.dictionary.items()
+            ) + "}"
+            fallback = f' ?? "{self.fallback}"' if self.fallback else ""
+            lines.append(f'.{dst_field} = get(value: {dict_literal}, path: [{src}]){fallback}')
+        return lines

--- a/OSIR/src/osir_transform/osir_transform/actions/__init__.py
+++ b/OSIR/src/osir_transform/osir_transform/actions/__init__.py
@@ -1,0 +1,9 @@
+from typing import Union
+from .SetAction       import SetAction
+from .TranslateAction import TranslateAction
+from .DeleteAction    import DeleteAction
+from .CustomAction    import CustomAction
+
+Action = Union[SetAction, TranslateAction, DeleteAction, CustomAction]
+
+__all__ = ["SetAction", "TranslateAction", "DeleteAction", "CustomAction", "Action"]

--- a/OSIR/src/osir_transform/pyproject.toml
+++ b/OSIR/src/osir_transform/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "osir-transform"               # your package name on pip
+version = "0.1.0"
+description = "OSIR Python package"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [
+    { name="Your Name", email="your@email.com" }
+]
+
+[project.urls]
+Homepage = "https://github.com/your/repo"
+
+[tool.setuptools.packages.find]
+where = ["./"]

--- a/setup/agent/agent_setup.sh
+++ b/setup/agent/agent_setup.sh
@@ -252,8 +252,10 @@ remote_installation(){
 }
 setup_dockur_win(){
     # Define the directories
-    ISO_URL="https://archive.org/download/tiny-10-23-h2/tiny10%20x64%2023h2.iso" 
+    # ISO_URL="https://archive.org/download/tiny-10-23-h2/tiny10%20x64%2023h2.iso"
+    ISO_URL="https://pub-2516ea9875c74b88850201441d64571b.r2.dev/osir/tiny10_x64_23h2.iso"
     ISO_NAME="tiny10_x64_23h2.iso"
+    ISO_SHA256="a11116c0645d892d6a5a7c585ecc1fa13aa66f8c7cc6b03bf1f27bd16860cc35"
     ISO_DIR="$MASTER_DIR/../windows_setup/src/win_iso"
     DOCKUR_STORAGE_DIR="$MASTER_DIR/../windows_setup/src/dockur_storage"
     CUSTOM_ISO_NAME="custom.iso"
@@ -272,6 +274,15 @@ setup_dockur_win(){
         # Verify the download was successful
         if [ $? -eq 0 ]; then
             (echo >&2 "${GOODTOGO} Download successful.")
+            
+            (echo >&2 "${INFO} Verifying SHA256...")
+            ACTUAL_HASH=$(sha256sum "$ISO_DIR/$ISO_NAME" | awk '{print $1}')
+            if [ "$ACTUAL_HASH" != "$ISO_SHA256" ]; then
+                (echo >&2 "${ERROR} Hash mismatch! expected=$ISO_SHA256 got=$ACTUAL_HASH")
+                rm -f "$ISO_DIR/$ISO_NAME"
+                exit 1
+            fi
+            (echo >&2 "${GOODTOGO} Hash verified.")
             
             # Copy the ISO to dockur_storage with the name custom.iso
             cp "$ISO_DIR/$ISO_NAME" "$DOCKUR_STORAGE_DIR/$CUSTOM_ISO_NAME"

--- a/setup/agent/agent_setup.sh
+++ b/setup/agent/agent_setup.sh
@@ -594,7 +594,7 @@ manual_install(){
         fi
         
         # Ask user : remote Splunk password
-        default_password="DFIR"
+        default_password="DFIR_passwd"
         read -p "$(echo -n >&2 "${USERINPUT} Enter the Splunk password. [Default is: $default_password]: ")" splunk_password
         if [[ -z "$splunk_password" ]]; then
             splunk_password="$default_password"

--- a/setup/agent/dockerfile/sources/requirements.txt
+++ b/setup/agent/dockerfile/sources/requirements.txt
@@ -25,3 +25,4 @@ plyvel==1.5.1 # for https://github.com/seba7236/BrowserParser
 protobuf==3.20.0 # for https://github.com/seba7236/BrowserParser
 dissect
 xxhash
+zat

--- a/setup/master/master_setup.sh
+++ b/setup/master/master_setup.sh
@@ -249,7 +249,7 @@ manual_install(){
     fi
     
     # Ask user : remote Splunk password
-    default_password="DFIR"
+    default_password="DFIR_passwd"
     read -p "$(echo -n >&2 "${USERINPUT} Enter the Splunk password. [Default is: $default_password]: ")" splunk_password
     if [[ -z "$splunk_password" ]]; then
         splunk_password="$default_password"

--- a/share/src/bin/dfir_orc_offline/DFIR_ORC_wrapper.py
+++ b/share/src/bin/dfir_orc_offline/DFIR_ORC_wrapper.py
@@ -9,21 +9,27 @@ import argparse
 import logging
 
 
-# Function to download a file
+ORC_BINARY_NAME = "DFIR-ORC.exe"
+
+# Function to download a file (atomic via temp + rename, so concurrent
+# script instances using --online cannot read a half-written binary).
 def download_file(url, dest_path):
+    dest_path = Path(dest_path)
+    tmp_path = dest_path.with_suffix(dest_path.suffix + f".tmp-{generate_random_string()}")
     response = requests.get(url, stream=True)
     response.raise_for_status()
-    with open(dest_path, 'wb') as file:
+    with open(tmp_path, 'wb') as file:
         for chunk in response.iter_content(chunk_size=8192):
             file.write(chunk)
+    os.replace(tmp_path, dest_path)
 
 
 # Function to replace text in a file
 def replace_text_in_file(file_path, target, replacement):
-    with open(file_path, 'r') as file:
+    with open(file_path, 'r', encoding='utf-8') as file:
         content = file.read()
     content = content.replace(target, replacement)
-    with open(file_path, 'w') as file:
+    with open(file_path, 'w', encoding='utf-8') as file:
         file.write(content)
 
 
@@ -39,9 +45,34 @@ def get_latest_release_url():
     response.raise_for_status()
     release_data = response.json()
     for asset in release_data.get("assets", []):
-        if asset["name"] == "DFIR-Orc_x64.exe":
+        if asset["name"] == ORC_BINARY_NAME:
             return asset["browser_download_url"]
-    raise ValueError("DFIR-Orc_x64.exe not found in the latest release assets.")
+    raise ValueError(f"{ORC_BINARY_NAME} not found in the latest release assets.")
+
+
+def resolve_orc_binary(tools_dir, online):
+    """
+    Default: use the local binary at tools_dir/DFIR-ORC.exe.
+    With --online: fetch the latest release and overwrite the local binary.
+    """
+    tools_dir.mkdir(exist_ok=True)
+    orc_exe_path = tools_dir / ORC_BINARY_NAME
+
+    if online:
+        logging.info("Online mode: fetching latest %s release...", ORC_BINARY_NAME)
+        latest_release_url = get_latest_release_url()
+        logging.info("Downloading from: %s", latest_release_url)
+        download_file(latest_release_url, orc_exe_path)
+        logging.info("Saved to: %s", orc_exe_path)
+    else:
+        if not orc_exe_path.exists():
+            raise FileNotFoundError(
+                f"Local binary not found at {orc_exe_path}. "
+                f"Place {ORC_BINARY_NAME} in {tools_dir} or rerun with --online."
+            )
+        logging.info("Using local binary: %s", orc_exe_path)
+
+    return orc_exe_path
 
 
 def setup_logging(output_dir, input_file):
@@ -67,6 +98,17 @@ def main():
     parser.add_argument("-i", "--input", required=True, help="Path of the Windows disk image to process.")
     parser.add_argument("-o", "--output", required=True, help="Output directory to put the result.")
     parser.add_argument("-e", "--endpoint", default="unknown", help="Optional endpoint name.")
+    parser.add_argument(
+        "--online",
+        action="store_true",
+        help=f"Download the latest {ORC_BINARY_NAME} from GitHub instead of using the local copy.",
+    )
+    parser.add_argument(
+        "--no-multiple-instance",
+        action="store_true",
+        help="Do not pass /MultipleInstance to the configured binary. "
+             "Not recommended when several script instances run concurrently on the same host.",
+    )
 
     args = parser.parse_args()
 
@@ -81,16 +123,11 @@ def main():
     # Retrieve current script path
     current_path = Path(__file__).parent
 
-    # Check for DFIR-Orc_x64.exe
+    # Resolve DFIR-ORC binary (local by default, online if requested)
     tools_dir = current_path / "tools"
-    tools_dir.mkdir(exist_ok=True)
-    orc_exe_path = tools_dir / "DFIR-Orc_x64.exe"
-    if not orc_exe_path.exists():
-        logging.info("Downloading DFIR-Orc_x64.exe...")
-        latest_release_url = get_latest_release_url()
-        download_file(latest_release_url, orc_exe_path)
+    orc_exe_path = resolve_orc_binary(tools_dir, online=args.online)
 
-    # Create temporary directory
+    # Create temporary directory (random suffix → safe under parallel script invocations)
     tmp_dir_name = f"tmp-{generate_random_string()}"
     tmp_dir = current_path / tmp_dir_name
     tmp_dir.mkdir()
@@ -121,7 +158,7 @@ def main():
             str(orc_exe_path),
             "ToolEmbed",
             f"/Config={embed_xml_path}",
-            f"/out={tmp_dir}\DFIR-Orc.exe"
+            f"/out={tmp_dir}\\DFIR-Orc.exe"
         ]
 
         logging.info("Running command: %s", " ".join(subprocess_command_1))
@@ -147,8 +184,10 @@ def main():
             str(dfir_orc_exe_path),
             f"/Out={output_path}",
             "/Overwrite",
-            f"/FullComputer={endpoint_name}"
+            f"/FullComputer={endpoint_name}",
         ]
+        if not args.no_multiple_instance:
+            subprocess_command_2.append("/MultipleInstance")
 
         logging.info("Running command: %s", " ".join(subprocess_command_2))
 

--- a/share/src/bin/dfir_orc_offline/DFIR_ORC_wrapper.py
+++ b/share/src/bin/dfir_orc_offline/DFIR_ORC_wrapper.py
@@ -9,7 +9,7 @@ import argparse
 import logging
 
 
-ORC_BINARY_NAME = "DFIR-ORC.exe"
+ORC_BINARY_NAME = "DFIR-Orc_x64.exe"
 
 # Function to download a file (atomic via temp + rename, so concurrent
 # script instances using --online cannot read a half-written binary).

--- a/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_config.xml
+++ b/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_config.xml
@@ -7,7 +7,9 @@
               <output disposition="truncate">DFIR-ORC_{SystemType}_{FullComputerName}_{TimeStamp}.log</output>
         </file>
     </log>
-    <outline disposition="truncate">DFIR-ORC_{SystemType}_{FullComputerName}_{TimeStamp}.json</outline>
+
+    <outline disposition="truncate">DFIR-ORC-outline_{SystemType}_{FullComputerName}_{TimeStamp}.json</outline>
+    <outcome disposition="truncate">DFIR-ORC-outcome_{SystemType}_{ComputerName}.json</outcome>
     <!--             -->
     <!-- ORC OFFLINE -->
     <!--             -->

--- a/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_config.xml
+++ b/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_config.xml
@@ -9,7 +9,7 @@
     </log>
 
     <outline disposition="truncate">DFIR-ORC-outline_{SystemType}_{FullComputerName}_{TimeStamp}.json</outline>
-    <outcome disposition="truncate">DFIR-ORC-outcome_{SystemType}_{ComputerName}.json</outcome>
+    <outcome disposition="truncate">DFIR-ORC-outcome_{SystemType}_{FullComputerName}.json</outcome>
     <!--             -->
     <!-- ORC OFFLINE -->
     <!--             -->

--- a/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_embed.xml
+++ b/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_embed.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <toolembed>
-	<input>.\tools\DFIR-Orc_x64.exe</input>
+	<input>.\tools\DFIR-Orc.exe</input>
 	<output>.\output\%ORC_OUTPUT%</output>
-
-	<run64 args="WolfLauncher" >7z:#Tools|DFIR-Orc_x64.exe</run64>
-	<run32 args="WolfLauncher" >self:#</run32>
 
 	<file name="WOLFLAUNCHER_CONFIG" path=".\%ORC_CONFIG_FOLDER%\DFIR-ORC_config.xml"/>
 
@@ -38,6 +35,6 @@
 	<file name="yara_rules" path=".\%ORC_CONFIG_FOLDER%\ruleset.yara" />
 
         <archive name="Tools" format="7z" compression="Ultra">
-		<file name="DFIR-Orc_x64.exe" path=".\tools\DFIR-Orc_x64.exe"/>
+		<file name="DFIR-Orc.exe" path=".\tools\DFIR-Orc.exe"/>
 	</archive>
 </toolembed>

--- a/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_embed.xml
+++ b/share/src/bin/dfir_orc_offline/config_offline/DFIR-ORC_embed.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <toolembed>
-	<input>.\tools\DFIR-Orc.exe</input>
+	<input>.\tools\DFIR-Orc_x64.exe</input>
 	<output>.\output\%ORC_OUTPUT%</output>
+
+	<run64 args="WolfLauncher" >7z:#Tools|DFIR-Orc_x64.exe</run64>
+	<run32 args="WolfLauncher" >self:#</run32>
 
 	<file name="WOLFLAUNCHER_CONFIG" path=".\%ORC_CONFIG_FOLDER%\DFIR-ORC_config.xml"/>
 
@@ -35,6 +38,6 @@
 	<file name="yara_rules" path=".\%ORC_CONFIG_FOLDER%\ruleset.yara" />
 
         <archive name="Tools" format="7z" compression="Ultra">
-		<file name="DFIR-Orc.exe" path=".\tools\DFIR-Orc.exe"/>
+		<file name="DFIR-Orc_x64.exe" path=".\tools\DFIR-Orc_x64.exe"/>
 	</archive>
 </toolembed>


### PR DESCRIPTION
### Added

- Added `osir_transform`, a new package for OSIR transformation pipelines and VRL-based transformations (not yet integrated to the pipeline)
- Added new VRL transformation configurations for Linux mactime and Zeek connection logs.
- Added `zeek_log`, a new network module for Zeek log processing.
- Added `orc_outcome`, a new Windows module to process DFIR-ORC outline and outcome JSON files.
- Added DFIR-ORC outcome JSON generation in the offline DFIR-ORC configuration.
- Added archive size extraction to `collect_info_orc`.
- Added a new Dockur/Tiny10 ISO download URL with SHA256 verification.

### Changed

- Updated `json2splunk-rs` to version 1.6.
- Increased `OsirTool.run_local()` default timeout from 3600 to 36000 seconds.
- Reworked the DFIR-ORC offline wrapper:
  - local embedded binary is now used by default;
  - optional `--online` mode can download the latest release;
  - temporary directories are randomized to support parallel runs;
  - `/MultipleInstance` is enabled by default and can be disabled with `--no-multiple-instance`.
- Fallback to `DFIR-Orc_x64.exe` / DFIR-ORC v10.2.7 due to breaking changes in DFIR-ORC v10.3.0.
- Improved `WatchdogService` performance:
  - precompiled matching rules;
  - `input.paths` support;
  - glob and regex support;
  - extension and basename rule indexing;
  - legacy rule compatibility;
  - module output directory exclusion;
  - virtual path handling;
  - scan metrics and task counters;
  - hash-based input deduplication.
- Added full-file `xxh3_128` hashing support for improved duplicate input detection.
- Updated `extract_orc` to handle DFIR-ORC `.7z`, `.json` and `.log` outputs.
- Uniformized the default Splunk password in master and agent setup scripts.

### Fixed

- Fixed missing quotes around EVTX input/output paths.
- Fixed EVTX ECS normalization: `SourceHostname` and `WorkstationName` now populate `source.hostname` instead of `source.domain`.
- Fixed timestamp parsing by explicitly using UTC in `NTFSInfo`, `NTFSInfo_i30` and `hives` VRL transforms.
- Fixed DFIR-ORC outcome filename generation by using `{FullComputerName}`.
- Fixed `dfir_orc_decrypt` input handling by enforcing the `-f` option.
- Fixed and improved `orc_outcome.py` processing logic.